### PR TITLE
Extend UI to Allow Displaying Other Types of  Models

### DIFF
--- a/src/main/java/seedu/contax/ui/ListContentType.java
+++ b/src/main/java/seedu/contax/ui/ListContentType.java
@@ -1,0 +1,8 @@
+package seedu.contax.ui;
+
+/**
+ * Represents the types of models that can be displayed by the UI.
+ */
+public enum ListContentType {
+    PERSON
+}

--- a/src/main/java/seedu/contax/ui/MainWindow.java
+++ b/src/main/java/seedu/contax/ui/MainWindow.java
@@ -35,6 +35,9 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+    // Flag indicating the type of model currently being displayed in the contentList
+    private ListContentType currentListType;
+
     @FXML
     private StackPane commandBoxPlaceholder;
 
@@ -42,7 +45,7 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane personListPanelPlaceholder;
+    private StackPane contentListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -66,6 +69,7 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+        currentListType = ListContentType.PERSON;
     }
 
     public Stage getPrimaryStage() {
@@ -111,7 +115,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        changeListContentType(ListContentType.PERSON);
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -132,6 +136,24 @@ public class MainWindow extends UiPart<Stage> {
         if (guiSettings.getWindowCoordinates() != null) {
             primaryStage.setX(guiSettings.getWindowCoordinates().getX());
             primaryStage.setY(guiSettings.getWindowCoordinates().getY());
+        }
+    }
+
+    /**
+     * Changes the type of model being displayed in the content list.
+     *
+     * @param contentType The type of content the UI should display.
+     */
+    private void changeListContentType(ListContentType contentType) {
+        contentListPanelPlaceholder.getChildren().removeAll();
+
+        if (contentType == null) {
+            return;
+        }
+
+        currentListType = contentType;
+        if (contentType == ListContentType.PERSON) {
+            contentListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
         }
     }
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,11 +46,11 @@
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <VBox fx:id="contentList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="contentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />


### PR DESCRIPTION
## Changes
This is a minor skeletal change to the UI to prepare it for displaying other types of models in its list window.

## Related Issues
None, this is a minor refactoring change.