### PR TITLE
Import CSV - Equals test for Command and Model

### DIFF
--- a/src/main/java/seedu/contax/model/IndexedCsvFile.java
+++ b/src/main/java/seedu/contax/model/IndexedCsvFile.java
@@ -65,8 +65,8 @@ public class IndexedCsvFile {
     }
 
     /**
-     * Returns true if both ImportCsv have the same filepath and position fields.
-     * This defines a stronger notion of equality between two ImportCsv objects.
+     * Returns true if both IndexedCsvFile have the same filepath and position fields.
+     * This defines a stronger notion of equality between two IndexedCsvFile objects.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/test/java/seedu/contax/logic/commands/ImportCsvCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ImportCsvCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.contax.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
@@ -137,5 +139,35 @@ public class ImportCsvCommandTest {
         expectedModel.addPerson(personBuilder2.build());
 
         assertCommandSuccess(importCsvCommand, model, ImportCsvCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        IndexedCsvFile csvFile1 = new ImportCsvObjectBuilder().build();
+        IndexedCsvFile csvFile2 = new ImportCsvObjectBuilder(ImportCsvObjectBuilder.SKIP_CSV_FILEPATH).build();
+        IndexedCsvFile csvFile3 = new ImportCsvObjectBuilder(ImportCsvObjectBuilder.SKIP_CSV_FILEPATH, 2,
+                3, 4, 5, 6).build();
+        ImportCsvCommand importCsvCommand1 = new ImportCsvCommand(csvFile1);
+        ImportCsvCommand importCsvCommand2 = new ImportCsvCommand(csvFile2);
+        ImportCsvCommand importCsvCommand3 = new ImportCsvCommand(csvFile3);
+
+        //same object -> returns true
+        assertTrue(importCsvCommand1.equals(importCsvCommand1));
+
+        //same values -> returns true
+        ImportCsvCommand duplicateOfCommand1 = new ImportCsvCommand(csvFile1);
+        assertTrue(importCsvCommand1.equals(duplicateOfCommand1));
+
+        //different types -> returns false
+        assertFalse(importCsvCommand1.equals(1));
+
+        //null -> returns false
+        assertFalse(importCsvCommand1.equals(null));
+
+        //different file opened -> returns false
+        assertFalse(importCsvCommand1.equals(importCsvCommand2));
+
+        //same file but different positions -> returns false
+        assertFalse(importCsvCommand2.equals(importCsvCommand3));
     }
 }

--- a/src/test/java/seedu/contax/model/IndexedCsvFileTest.java
+++ b/src/test/java/seedu/contax/model/IndexedCsvFileTest.java
@@ -46,4 +46,36 @@ public class IndexedCsvFileTest {
         //file with no name has the extension, no such file will exist anyway so it doesn't matter if it is valid
         assertTrue(IndexedCsvFile.isValidFilePath(".csv"));
     }
+
+    @Test
+    public void equals() {
+        //same object -> returns true
+        IndexedCsvFile csvFile1 = new IndexedCsvFile(new File("/data/file.csv"), 1,
+                2, 3, 4, 5);
+        assertTrue(csvFile1.equals(csvFile1));
+
+        //same values -> returns true
+        IndexedCsvFile csvFile2 = new IndexedCsvFile(new File("/data/file.csv"), 1,
+                2, 3, 4, 5);
+        assertTrue(csvFile1.equals(csvFile2));
+
+        //null -> returns false
+        assertFalse(csvFile1.equals(null));
+
+        //different filename -> returns false
+        assertFalse(csvFile1.equals(new IndexedCsvFile(new File("file.csv"), 1,
+                2, 3, 4, 5)));
+
+        //different positions -> returns false
+        assertFalse(csvFile1.equals(new IndexedCsvFile(new File("file.csv"), 6,
+                2, 3, 4, 5)));
+        assertFalse(csvFile1.equals(new IndexedCsvFile(new File("file.csv"), 1,
+                6, 3, 4, 5)));
+        assertFalse(csvFile1.equals(new IndexedCsvFile(new File("file.csv"), 1,
+                2, 6, 4, 5)));
+        assertFalse(csvFile1.equals(new IndexedCsvFile(new File("file.csv"), 1,
+                2, 3, 6, 5)));
+        assertFalse(csvFile1.equals(new IndexedCsvFile(new File("file.csv"), 1,
+                2, 3, 4, 6)));
+    }
 }


### PR DESCRIPTION
This PR adds the equals test for the `IndexedCsvFile` model and the `ImportCsvCommand` command. Was supposed to be in #132 but I forgot to add it 

Related PR: #132 
Related Issue: #92 