### PR TITLE
Add Cascading Delete and Update for Persons

### DIFF
--- a/src/main/java/seedu/contax/model/ModelManager.java
+++ b/src/main/java/seedu/contax/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.contax.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -114,6 +116,16 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
+
+        // Delete Successful, dissociate target with any appointments.
+        // The list of matching appointments is cloned because the list iterator is destroyed upon
+        // any modification to the list.
+        List<Appointment> oldAppointments = new ArrayList<>(
+                schedule.getAppointmentList()
+                        .filtered(appointment -> appointment.getPerson().equals(target)));
+        oldAppointments.forEach(appointment -> {
+            setAppointment(appointment, appointment.withPerson(null));
+        });
     }
 
     @Override
@@ -127,6 +139,17 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+
+        // Update success, update appointments with target.
+        // The list of matching appointments is cloned because the list iterator is destroyed upon
+        // any modification to the list.
+        List<Appointment> oldAppointments = new ArrayList<>(
+                schedule.getAppointmentList()
+                        .filtered(appointment -> appointment.getPerson().equals(target)));
+
+        oldAppointments.forEach(appointment -> {
+            setAppointment(appointment, appointment.withPerson(editedPerson));
+        });
     }
 
     // Tag management

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -10,6 +10,8 @@ import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_ALONE;
 import static seedu.contax.testutil.TypicalAppointments.getTypicalSchedule;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
 import static seedu.contax.testutil.TypicalPersons.BENSON;
+import static seedu.contax.testutil.TypicalPersons.BOB;
+import static seedu.contax.testutil.TypicalPersons.CARL;
 import static seedu.contax.testutil.TypicalTags.CLIENTS;
 import static seedu.contax.testutil.TypicalTags.FAMILY;
 
@@ -23,6 +25,7 @@ import seedu.contax.commons.core.GuiSettings;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.exceptions.AppointmentNotFoundException;
 import seedu.contax.model.person.NameContainsKeywordsPredicate;
+import seedu.contax.model.person.exceptions.PersonNotFoundException;
 import seedu.contax.testutil.AddressBookBuilder;
 import seedu.contax.testutil.AppointmentBuilder;
 import seedu.contax.testutil.ScheduleBuilder;
@@ -107,6 +110,87 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void deletePerson_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.deletePerson(null));
+    }
+
+    @Test
+    public void deletePerson_personNotInAddressBook_throwsPersonNotFoundException() {
+        assertThrows(PersonNotFoundException.class, () -> modelManager.deletePerson(ALICE));
+    }
+
+    @Test
+    public void deletePerson_personInAddressBookNoAppointments_success() {
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BOB);
+        modelManager.deletePerson(ALICE);
+
+        ModelManager expectedModel = new ModelManager();
+        expectedModel.addPerson(BOB);
+        assertEquals(expectedModel, modelManager);
+    }
+
+    @Test
+    public void deletePerson_personInAddressBookHasAppointments_success() {
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BOB);
+        modelManager.addAppointment(APPOINTMENT_ALICE);
+        Appointment appointment2 = new AppointmentBuilder(APPOINTMENT_ALONE).withPerson(BOB).build();
+        modelManager.addAppointment(appointment2);
+
+        modelManager.deletePerson(ALICE);
+
+        ModelManager expectedModel = new ModelManager();
+        expectedModel.addPerson(BOB);
+        expectedModel.addAppointment(new AppointmentBuilder(APPOINTMENT_ALICE).withPerson(null).build());
+        expectedModel.addAppointment(appointment2);
+        assertEquals(expectedModel, modelManager);
+    }
+
+    @Test
+    public void setPerson_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setPerson(null, null));
+        assertThrows(NullPointerException.class, () -> modelManager.setPerson(ALICE, null));
+        assertThrows(NullPointerException.class, () -> modelManager.setPerson(null, ALICE));
+    }
+
+    @Test
+    public void setPerson_personNotInAddressBook_throwsPersonNotFoundException() {
+        assertThrows(PersonNotFoundException.class, () -> modelManager.setPerson(ALICE, ALICE));
+    }
+
+    @Test
+    public void setPerson_personInAddressBookNoAppointments_success() {
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BOB);
+
+        modelManager.setPerson(ALICE, CARL);
+
+        ModelManager expectedModel = new ModelManager();
+        expectedModel.addPerson(CARL);
+        expectedModel.addPerson(BOB);
+        assertEquals(expectedModel, modelManager);
+    }
+
+    @Test
+    public void setPerson_personInAddressBookHasAppointments_success() {
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BOB);
+        modelManager.addAppointment(APPOINTMENT_ALICE);
+        Appointment appointment2 = new AppointmentBuilder(APPOINTMENT_ALONE).withPerson(BOB).build();
+        modelManager.addAppointment(appointment2);
+
+        modelManager.setPerson(ALICE, CARL);
+
+        ModelManager expectedModel = new ModelManager();
+        expectedModel.addPerson(CARL);
+        expectedModel.addPerson(BOB);
+        expectedModel.addAppointment(new AppointmentBuilder(APPOINTMENT_ALICE).withPerson(CARL).build());
+        expectedModel.addAppointment(appointment2);
+        assertEquals(expectedModel, modelManager);
     }
 
     @Test


### PR DESCRIPTION
## Changes
This PR directly addresses bug #151 that results in an inconsistent model state by asserting model consistency at the ModelManager level. Tests were also added to verify that the cascading modifications and delete work as intended.

## Related Issues
- Closes #151 