### PR TITLE
Small fix for onboarding instruction label

### DIFF
--- a/src/main/java/seedu/contax/ui/onboarding/OnboardingInstruction.java
+++ b/src/main/java/seedu/contax/ui/onboarding/OnboardingInstruction.java
@@ -20,8 +20,6 @@ public class OnboardingInstruction extends UiPart<Region> {
      */
     public OnboardingInstruction() {
         super(FXML);
-        instruction.setStyle("-fx-background-color: rgba(25, 25, 25, 1)");
-        instruction.setWrapText(true);
     }
 
     public void show() {

--- a/src/main/java/seedu/contax/ui/onboarding/OnboardingInstruction.java
+++ b/src/main/java/seedu/contax/ui/onboarding/OnboardingInstruction.java
@@ -21,6 +21,7 @@ public class OnboardingInstruction extends UiPart<Region> {
     public OnboardingInstruction() {
         super(FXML);
         instruction.setStyle("-fx-background-color: rgba(25, 25, 25, 1)");
+        instruction.setWrapText(true);
     }
 
     public void show() {

--- a/src/main/java/seedu/contax/ui/onboarding/OnboardingWindow.java
+++ b/src/main/java/seedu/contax/ui/onboarding/OnboardingWindow.java
@@ -234,7 +234,6 @@ public class OnboardingWindow extends UiPart<Stage> {
             instructionLabel.translate(resultDisplayPlaceholder.layoutXProperty(),
                     resultDisplayPlaceholder.layoutYProperty());
         } else if (option == 4) {
-            System.out.println(resultDisplayPlaceholder.getMaxHeight());
             instructionLabel.translate(
                     personList.layoutXProperty().add(0),
                     personList.layoutYProperty().add(

--- a/src/main/resources/view/onboarding/OnboardingInstruction.fxml
+++ b/src/main/resources/view/onboarding/OnboardingInstruction.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <Label fx:id="instruction" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" styleClass="label-instruction" />
+  <Label fx:id="instruction" wrapText="true" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" styleClass="label-instruction" />
 </StackPane>


### PR DESCRIPTION
This PR fixes the bug which causes the instruction display message to be cut off.

## Closes
- closes #148 