### PR TITLE
Refactor ListContentType to Commons Package

### DIFF
--- a/src/main/java/seedu/contax/commons/core/GuiListContentType.java
+++ b/src/main/java/seedu/contax/commons/core/GuiListContentType.java
@@ -1,9 +1,9 @@
-package seedu.contax.ui;
+package seedu.contax.commons.core;
 
 /**
  * Represents the types of models that can be displayed by the UI.
  */
-public enum ListContentType {
+public enum GuiListContentType {
     PERSON,
     APPOINTMENT,
     TAG,

--- a/src/main/java/seedu/contax/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/contax/logic/commands/CommandResult.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Represents the result of a command execution.
@@ -12,7 +12,7 @@ import seedu.contax.ui.ListContentType;
 public class CommandResult {
 
     private final String feedbackToUser;
-    private final ListContentType uiContentType;
+    private final GuiListContentType uiContentType;
 
     /** Help information should be shown to the user. */
     private final boolean showHelp;
@@ -23,7 +23,7 @@ public class CommandResult {
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, ListContentType contentType, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, GuiListContentType contentType, boolean showHelp, boolean exit) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
@@ -35,14 +35,14 @@ public class CommandResult {
      * and other fields set to their default value. The contents the list shows defaults to {@code UNCHANGED}.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, ListContentType.UNCHANGED, false, false);
+        this(feedbackToUser, GuiListContentType.UNCHANGED, false, false);
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser} and the
      * {@code contentType} to display in the content list.
      */
-    public CommandResult(String feedbackToUser, ListContentType contentType) {
+    public CommandResult(String feedbackToUser, GuiListContentType contentType) {
         this(feedbackToUser, contentType, false, false);
     }
 
@@ -51,14 +51,14 @@ public class CommandResult {
      * {@code exit}. The contents the list shows defaults to {@code UNCHANGED}.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this(feedbackToUser, ListContentType.UNCHANGED, showHelp, exit);
+        this(feedbackToUser, GuiListContentType.UNCHANGED, showHelp, exit);
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
     }
 
-    public ListContentType getUiContentType() {
+    public GuiListContentType getUiContentType() {
         return uiContentType;
     }
 

--- a/src/main/java/seedu/contax/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/FindCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.contax.commons.core.Messages;
 import seedu.contax.model.Model;
 import seedu.contax.model.person.ContainsKeywordsPredicate;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -32,7 +32,7 @@ public class FindCommand extends Command {
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
     }
 
     @Override

--- a/src/main/java/seedu/contax/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/FindCommand.java
@@ -2,10 +2,10 @@ package seedu.contax.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.commons.core.Messages;
 import seedu.contax.model.Model;
 import seedu.contax.model.person.ContainsKeywordsPredicate;
-import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.

--- a/src/main/java/seedu/contax/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListAppointmentCommand.java
@@ -2,8 +2,8 @@ package seedu.contax.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.contax.model.Model;
 import seedu.contax.commons.core.GuiListContentType;
+import seedu.contax.model.Model;
 
 /**
  * Lists all persons in the address book to the user.

--- a/src/main/java/seedu/contax/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListAppointmentCommand.java
@@ -3,7 +3,7 @@ package seedu.contax.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.contax.model.Model;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Lists all persons in the address book to the user.
@@ -18,6 +18,6 @@ public class ListAppointmentCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        return new CommandResult(MESSAGE_SUCCESS, ListContentType.APPOINTMENT);
+        return new CommandResult(MESSAGE_SUCCESS, GuiListContentType.APPOINTMENT);
     }
 }

--- a/src/main/java/seedu/contax/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListCommand.java
@@ -3,8 +3,8 @@ package seedu.contax.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.contax.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import seedu.contax.model.Model;
 import seedu.contax.commons.core.GuiListContentType;
+import seedu.contax.model.Model;
 
 /**
  * Lists all persons in the address book to the user.

--- a/src/main/java/seedu/contax/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListCommand.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.contax.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.contax.model.Model;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Lists all persons in the address book to the user.
@@ -20,6 +20,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, ListContentType.PERSON);
+        return new CommandResult(MESSAGE_SUCCESS, GuiListContentType.PERSON);
     }
 }

--- a/src/main/java/seedu/contax/logic/commands/ListTagCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListTagCommand.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.contax.logic.commands.exceptions.CommandException;
 import seedu.contax.model.Model;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Lists all tags in the address book to the user.
@@ -17,6 +17,6 @@ public class ListTagCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        return new CommandResult(MESSAGE_SUCCESS, ListContentType.TAG);
+        return new CommandResult(MESSAGE_SUCCESS, GuiListContentType.TAG);
     }
 }

--- a/src/main/java/seedu/contax/logic/commands/ListTagCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListTagCommand.java
@@ -2,9 +2,9 @@ package seedu.contax.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.logic.commands.exceptions.CommandException;
 import seedu.contax.model.Model;
-import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Lists all tags in the address book to the user.

--- a/src/main/java/seedu/contax/ui/MainWindow.java
+++ b/src/main/java/seedu/contax/ui/MainWindow.java
@@ -10,6 +10,7 @@ import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.commons.core.GuiSettings;
 import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.logic.Logic;
@@ -40,7 +41,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private OnboardingPrompt onboardingPrompt;
     // Flag indicating the type of model currently being displayed in the contentList
-    private ListContentType currentListType;
+    private GuiListContentType currentListType;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -125,7 +126,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         appointmentListPanel = new AppointmentListPanel(logic.getAppointmentList());
         tagListPanel = new TagListPanel(logic.getTagList());
-        changeListContentType(ListContentType.PERSON);
+        changeListContentType(GuiListContentType.PERSON);
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -154,24 +155,24 @@ public class MainWindow extends UiPart<Stage> {
      *
      * @param contentType The type of content the UI should display.
      */
-    private void changeListContentType(ListContentType contentType) {
+    private void changeListContentType(GuiListContentType contentType) {
         if (contentType == null) {
             contentListPanelPlaceholder.getChildren().clear();
             return;
         }
 
-        if (contentType.equals(ListContentType.UNCHANGED) || contentType.equals(currentListType)) {
+        if (contentType.equals(GuiListContentType.UNCHANGED) || contentType.equals(currentListType)) {
             return;
         }
 
         contentListPanelPlaceholder.getChildren().clear();
         currentListType = contentType;
 
-        if (contentType == ListContentType.PERSON) {
+        if (contentType == GuiListContentType.PERSON) {
             contentListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
-        } else if (contentType == ListContentType.APPOINTMENT) {
+        } else if (contentType == GuiListContentType.APPOINTMENT) {
             contentListPanelPlaceholder.getChildren().add(appointmentListPanel.getRoot());
-        } else if (contentType == ListContentType.TAG) {
+        } else if (contentType == GuiListContentType.TAG) {
             contentListPanelPlaceholder.getChildren().add(tagListPanel.getRoot());
         }
     }

--- a/src/test/java/seedu/contax/logic/commands/ChainCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ChainCommandTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.model.AddressBook;
 import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
@@ -18,7 +19,6 @@ import seedu.contax.model.UserPrefs;
 import seedu.contax.model.person.Person;
 import seedu.contax.testutil.EditPersonDescriptorBuilder;
 import seedu.contax.testutil.PersonBuilder;
-import seedu.contax.commons.core.GuiListContentType;
 
 public class ChainCommandTest {
     private Model model;

--- a/src/test/java/seedu/contax/logic/commands/ChainCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ChainCommandTest.java
@@ -18,7 +18,7 @@ import seedu.contax.model.UserPrefs;
 import seedu.contax.model.person.Person;
 import seedu.contax.testutil.EditPersonDescriptorBuilder;
 import seedu.contax.testutil.PersonBuilder;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 public class ChainCommandTest {
     private Model model;
@@ -34,7 +34,7 @@ public class ChainCommandTest {
     public void execute_chainedList_success() {
         assertCommandSuccess(new ChainCommand(List.of(new ListCommand())), model,
                 new CommandResult(ListCommand.MESSAGE_SUCCESS,
-                ListContentType.PERSON), expectedModel);
+                GuiListContentType.PERSON), expectedModel);
     }
 
     @Test
@@ -54,6 +54,6 @@ public class ChainCommandTest {
 
         assertCommandSuccess(new ChainCommand(commandList),
                 model, new CommandResult(ListCommand.MESSAGE_SUCCESS,
-                ListContentType.PERSON), expectedModel);
+                GuiListContentType.PERSON), expectedModel);
     }
 }

--- a/src/test/java/seedu/contax/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/contax/logic/commands/CommandResultTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 public class CommandResultTest {
     @Test
@@ -16,7 +16,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", ListContentType.UNCHANGED,
+        assertTrue(commandResult.equals(new CommandResult("feedback", GuiListContentType.UNCHANGED,
                 false, false)));
 
         // same object -> returns true
@@ -32,15 +32,15 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different content type -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", ListContentType.PERSON,
+        assertFalse(commandResult.equals(new CommandResult("feedback", GuiListContentType.PERSON,
                 false, false)));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", ListContentType.UNCHANGED,
+        assertFalse(commandResult.equals(new CommandResult("feedback", GuiListContentType.UNCHANGED,
                 true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", ListContentType.UNCHANGED,
+        assertFalse(commandResult.equals(new CommandResult("feedback", GuiListContentType.UNCHANGED,
                 false, true)));
     }
 
@@ -55,15 +55,15 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different content type -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", ListContentType.PERSON,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", GuiListContentType.PERSON,
                 false, false).hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", ListContentType.UNCHANGED,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", GuiListContentType.UNCHANGED,
                 true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", ListContentType.UNCHANGED,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", GuiListContentType.UNCHANGED,
                 false, true).hashCode());
     }
 }

--- a/src/test/java/seedu/contax/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/FindCommandTest.java
@@ -23,7 +23,7 @@ import seedu.contax.model.person.AddressContainsKeywordsPredicate;
 import seedu.contax.model.person.EmailContainsKeywordsPredicate;
 import seedu.contax.model.person.NameContainsKeywordsPredicate;
 import seedu.contax.model.person.PhoneContainsKeywordsPredicate;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -143,7 +143,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -154,7 +154,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFoundPhone() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         PhoneContainsKeywordsPredicate predicate = preparePhonePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -165,7 +165,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFoundEmail() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         EmailContainsKeywordsPredicate predicate = prepareEmailPredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -176,7 +176,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFoundAddress() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         AddressContainsKeywordsPredicate predicate = prepareAddressPredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -187,7 +187,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -198,7 +198,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFoundPhone() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         PhoneContainsKeywordsPredicate predicate = preparePhonePredicate("95352563 9482224 9482427");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -209,7 +209,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFoundEmail() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         EmailContainsKeywordsPredicate predicate = prepareEmailPredicate(
                 "heinz@example.com werner@example.com lydia@example.com");
         FindCommand command = new FindCommand(predicate);
@@ -221,7 +221,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFoundAddress() {
         CommandResult expectedResult = new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2),
-                ListContentType.PERSON);
+                GuiListContentType.PERSON);
         AddressContainsKeywordsPredicate predicate = prepareAddressPredicate(
                 "wall michegan");
         FindCommand command = new FindCommand(predicate);

--- a/src/test/java/seedu/contax/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/FindCommandTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.Schedule;
@@ -23,7 +24,6 @@ import seedu.contax.model.person.AddressContainsKeywordsPredicate;
 import seedu.contax.model.person.EmailContainsKeywordsPredicate;
 import seedu.contax.model.person.NameContainsKeywordsPredicate;
 import seedu.contax.model.person.PhoneContainsKeywordsPredicate;
-import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.

--- a/src/test/java/seedu/contax/logic/commands/ListAppointmentCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ListAppointmentCommandTest.java
@@ -6,11 +6,11 @@ import static seedu.contax.testutil.TypicalAppointments.getTypicalSchedule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.model.AddressBook;
 import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.

--- a/src/test/java/seedu/contax/logic/commands/ListAppointmentCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ListAppointmentCommandTest.java
@@ -10,7 +10,7 @@ import seedu.contax.model.AddressBook;
 import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -29,6 +29,6 @@ public class ListAppointmentCommandTest {
     @Test
     public void execute_valid_listsAllAppointments() {
         assertCommandSuccess(new ListAppointmentCommand(), model, new CommandResult(
-                ListAppointmentCommand.MESSAGE_SUCCESS, ListContentType.APPOINTMENT), expectedModel);
+                ListAppointmentCommand.MESSAGE_SUCCESS, GuiListContentType.APPOINTMENT), expectedModel);
     }
 }

--- a/src/test/java/seedu/contax/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ListCommandTest.java
@@ -12,7 +12,7 @@ import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.Schedule;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -31,13 +31,13 @@ public class ListCommandTest {
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
         assertCommandSuccess(new ListCommand(), model, new CommandResult(ListCommand.MESSAGE_SUCCESS,
-                ListContentType.PERSON), expectedModel);
+                GuiListContentType.PERSON), expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, new CommandResult(ListCommand.MESSAGE_SUCCESS,
-                ListContentType.PERSON), expectedModel);
+                GuiListContentType.PERSON), expectedModel);
     }
 }

--- a/src/test/java/seedu/contax/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ListCommandTest.java
@@ -8,11 +8,11 @@ import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.Schedule;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.

--- a/src/test/java/seedu/contax/logic/commands/ListTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ListTagCommandTest.java
@@ -10,7 +10,7 @@ import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.Schedule;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.ui.ListContentType;
+import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with Model) and units tests for ListTagCommand
@@ -28,6 +28,6 @@ public class ListTagCommandTest {
     @Test
     public void execute_valid_listAllTags() {
         assertCommandSuccess(new ListTagCommand(), model, new CommandResult(ListTagCommand.MESSAGE_SUCCESS,
-                ListContentType.TAG), expectedModel);
+                GuiListContentType.TAG), expectedModel);
     }
 }

--- a/src/test/java/seedu/contax/logic/commands/ListTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ListTagCommandTest.java
@@ -6,11 +6,11 @@ import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.Schedule;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.commons.core.GuiListContentType;
 
 /**
  * Contains integration tests (interaction with Model) and units tests for ListTagCommand


### PR DESCRIPTION
## Changes
This PR refactors the `ListContentType` enum into the commons package to better reflect its usage in both the Logic component and the GUI component. It is also renamed to `GuiListContentType` to better indicate its purpose.

## Related Issues
- None