### PR TITLE
Fix - Person-Tag Integrity Enforcement

### DIFF
--- a/src/main/java/seedu/contax/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/DeleteTagCommand.java
@@ -29,7 +29,6 @@ public class DeleteTagCommand extends Command {
         this.targetIndex = targetIndex;
     }
 
-
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);

--- a/src/main/java/seedu/contax/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/contax/logic/parser/AddressBookParser.java
@@ -94,14 +94,16 @@ public class AddressBookParser {
         case AddTagCommand.COMMAND_WORD:
             return new AddTagCommandParser().parse(arguments);
 
-        case ChainCommand.COMMAND_WORD:
-            return new ChainCommandParser().parse(arguments);
-
         case ListTagCommand.COMMAND_WORD:
             return new ListTagCommand();
 
         case DeleteTagCommand.COMMAND_WORD:
             return new DeleteTagCommandParser().parse(arguments);
+
+        // Command chaining
+        case ChainCommand.COMMAND_WORD:
+            return new ChainCommandParser().parse(arguments);
+
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -130,7 +130,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * The supplied tag must already exist in the address book.
      */
     public void removeTag(Tag tagToDelete) {
-        removePersonsWithTag(tagToDelete);
+        removeTagFromPersons(tagToDelete);
         tags.remove(tagToDelete);
     }
 
@@ -147,9 +147,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Disassociates the specified tag from all persons in the address book.
      */
-    private void removePersonsWithTag(Tag tagToDelete) {
+    private void removeTagFromPersons(Tag tagToDelete) {
         requireNonNull(tagToDelete);
-        List<Person> persons = getPersonList().filtered(person -> person.getTags().contains(tagToDelete));
+        List<Person> persons = getPersonList().filtered(person -> person.hasTag(tagToDelete));
         for (int i = 0; i < persons.size(); i++) {
             Person oldPerson = persons.get(i);
             setPerson(oldPerson, oldPerson.withoutTag(tagToDelete));

--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import javafx.collections.ObservableList;
 import seedu.contax.model.person.Person;
@@ -81,6 +82,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * The person must not already exist in the address book.
      */
     public void addPerson(Person p) {
+        addTagsNotInList(p);
         persons.add(p);
     }
 
@@ -91,7 +93,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
+        addTagsNotInList(editedPerson);
         persons.setPerson(target, editedPerson);
     }
 
@@ -106,7 +108,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// tag-level operations
 
     /**
-     * Returns true if there exists a {@code tag} with the same name in ContaX.
+     * Returns true if a matching {@code tag} exists in the address book.
      * @param tag The tag specified tag to search.
      * @return true if the tag exists in the tags list.
      */
@@ -115,12 +117,72 @@ public class AddressBook implements ReadOnlyAddressBook {
         return tags.contains(tag);
     }
 
+    /**
+     * Adds the given tag into the address book.
+     * Tag must not already exist in the address book.
+     */
     public void addTag(Tag tag) {
         tags.add(tag);
     }
 
+    /**
+     * Deletes the given tag from the address book.
+     * The supplied tag must already exist in the address book.
+     */
     public void removeTag(Tag tagToDelete) {
+        removePersonsWithTag(tagToDelete);
         tags.remove(tagToDelete);
+    }
+
+    /**
+     * Replaces the given {@code target} with {@code editedTag}.
+     * {@code target} must exist in the address book.
+     * {@code editedTag} must not be the same as another existing tag in the address book.
+     */
+    public void setTag(Tag target, Tag editedTag) {
+        tags.setTag(target, editedTag);
+        setPersonsWithTag(target, editedTag);
+    }
+
+    /**
+     * Disassociates the specified tag from all persons in the address book.
+     */
+    private void removePersonsWithTag(Tag tagToDelete) {
+        requireNonNull(tagToDelete);
+        List<Person> persons = getPersonList().filtered(person -> person.getTags().contains(tagToDelete));
+        for (int i = 0; i < persons.size(); i++) {
+            Person oldPerson = persons.get(i);
+            setPerson(oldPerson, oldPerson.withoutTag(tagToDelete));
+        }
+    }
+
+    /**
+     * Adds tags in {@code persons} that do not exist in the address book.
+     */
+    private void addTagsNotInList(Person person) {
+        requireNonNull(person);
+        Set<Tag> tagSet = person.getTags();
+        for (Tag personTag : tagSet) {
+            if (!tags.contains(personTag)) {
+                addTag(personTag);
+            }
+        }
+    }
+
+    /**
+     * Replaces {@code target} with {@code editedTag} in all persons of the address book.
+     */
+    private void setPersonsWithTag(Tag target, Tag editedTag) {
+        requireNonNull(target);
+        requireNonNull(editedTag);
+
+        List<Person> personsWithTag = getPersonList().filtered(person -> person.hasTag(target));
+
+        for (int i = 0; i < personsWithTag.size(); i++) {
+            Person person = personsWithTag.get(i);
+            Person editedPerson = person.withoutTag(target).withTag(editedTag);
+            setPerson(person, editedPerson);
+        }
     }
 
     //// util methods

--- a/src/main/java/seedu/contax/model/Model.java
+++ b/src/main/java/seedu/contax/model/Model.java
@@ -8,6 +8,7 @@ import seedu.contax.commons.core.GuiSettings;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
+import seedu.contax.model.tag.exceptions.DuplicateTagException;
 
 /**
  * The API of the Model component.
@@ -88,11 +89,29 @@ public interface Model {
     void updateFilteredPersonList(Predicate<Person> predicate);
 
     // Tag management
+    /**
+     * Returns true if a matching {@code tag} exists in the address book.
+     */
     boolean hasTag(Tag tag);
 
+    /**
+     * Adds the given tag into the address book.
+     * Tag must not already exist in the address book.
+     */
     void addTag(Tag tag);
 
+    /**
+     * Deletes the given tag from the address book.
+     * The supplied tag must already exist in the address book.
+     */
     void deleteTag(Tag tagToDelete);
+
+    /**
+     * Replaces the given {@code target} with {@code editedTag}.
+     * {@code target} must exist in the address book.
+     * {@code editedTag} must not be the same as another existing tag in the address book.
+     */
+    void setTag(Tag target, Tag editedTag);
 
     ObservableList<Tag> getTagList();
 

--- a/src/main/java/seedu/contax/model/Model.java
+++ b/src/main/java/seedu/contax/model/Model.java
@@ -8,7 +8,6 @@ import seedu.contax.commons.core.GuiSettings;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
-import seedu.contax.model.tag.exceptions.DuplicateTagException;
 
 /**
  * The API of the Model component.

--- a/src/main/java/seedu/contax/model/ModelManager.java
+++ b/src/main/java/seedu/contax/model/ModelManager.java
@@ -167,17 +167,12 @@ public class ModelManager implements Model {
     @Override
     public void deleteTag(Tag tagToDelete) {
         requireNonNull(tagToDelete);
-        removeTagFromPersons(tagToDelete);
         addressBook.removeTag(tagToDelete);
     }
 
-    private void removeTagFromPersons(Tag tagToDelete) {
-        requireNonNull(tagToDelete);
-        List<Person> persons = addressBook.getPersonList().filtered(person -> person.getTags().contains(tagToDelete));
-        for (int i = 0; i < persons.size(); i++) {
-            Person oldPerson = persons.get(i);
-            setPerson(oldPerson, oldPerson.withoutTag(tagToDelete));
-        }
+    @Override
+    public void setTag(Tag target, Tag editedTag) {
+        addressBook.setTag(target, editedTag);
     }
 
     @Override

--- a/src/main/java/seedu/contax/model/ModelManager.java
+++ b/src/main/java/seedu/contax/model/ModelManager.java
@@ -172,6 +172,9 @@ public class ModelManager implements Model {
 
     @Override
     public void setTag(Tag target, Tag editedTag) {
+        requireNonNull(target);
+        requireNonNull(editedTag);
+
         addressBook.setTag(target, editedTag);
     }
 

--- a/src/main/java/seedu/contax/model/person/Person.java
+++ b/src/main/java/seedu/contax/model/person/Person.java
@@ -82,6 +82,10 @@ public class Person {
         return new Person(name, phone, email, address, updatedTag);
     }
 
+    public boolean hasTag(Tag tag) {
+        return tags.contains(tag);
+    }
+
     /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.

--- a/src/main/java/seedu/contax/model/person/Person.java
+++ b/src/main/java/seedu/contax/model/person/Person.java
@@ -82,6 +82,9 @@ public class Person {
         return new Person(name, phone, email, address, updatedTag);
     }
 
+    /**
+     * Returns true if the specified tag exists in the {@code person}.
+     */
     public boolean hasTag(Tag tag) {
         return tags.contains(tag);
     }

--- a/src/main/java/seedu/contax/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/contax/model/tag/UniqueTagList.java
@@ -69,6 +69,19 @@ public class UniqueTagList implements Iterable<Tag> {
         internalList.setAll(tags);
     }
 
+    public void setTag(Tag target, Tag editedTag) {
+        requireNonNull(target);
+        requireNonNull(editedTag);
+
+        // Checks if edited Tag exists
+        if (contains(editedTag)) {
+            throw new DuplicateTagException();
+        }
+
+        int targetIndex = internalList.indexOf(target);
+        internalList.set(targetIndex, editedTag);
+    }
+
     public ObservableList<Tag> asUnmodifiableObservableList() {
         return internalUnmodifiableList;
     }

--- a/src/main/java/seedu/contax/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/contax/model/tag/UniqueTagList.java
@@ -69,9 +69,17 @@ public class UniqueTagList implements Iterable<Tag> {
         internalList.setAll(tags);
     }
 
+    /**
+     * Replaces the specified {@code target} tag with {@code editedTag}.
+     */
     public void setTag(Tag target, Tag editedTag) {
         requireNonNull(target);
         requireNonNull(editedTag);
+
+        // Checks if Tags are the same
+        if (target.equals(editedTag)) {
+            return;
+        }
 
         // Checks if edited Tag exists
         if (contains(editedTag)) {

--- a/src/test/java/seedu/contax/logic/commands/AddAppointmentCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddAppointmentCommandTest.java
@@ -209,7 +209,8 @@ public class AddAppointmentCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        private void removeTagFromPersons(Tag tagToDelete) {
+        @Override
+        public void setTag(Tag target, Tag editedTag) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddCommandTest.java
@@ -166,7 +166,8 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        private void removeTagFromPersons(Tag tagToDelete) {
+        @Override
+        public void setTag(Tag target, Tag editedTag) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
@@ -178,7 +178,8 @@ class AddTagCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        private void removeTagFromPersons(Tag tagToDelete) {
+        @Override
+        public void setTag(Tag target, Tag editedTag) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
@@ -2,7 +2,11 @@ package seedu.contax.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.contax.testutil.TypicalPersons.COLLEAGUES;
+import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -45,6 +49,19 @@ class AddTagCommandTest {
         Tag duplicate = new TagBuilder().build();
 
         assertThrows(CommandException.class, () -> new AddTagCommand(duplicate).execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        AddTagCommand addCommand = new AddTagCommand(FRIENDS);
+        AddTagCommand addCommand2 = new AddTagCommand(COLLEAGUES);
+
+        assertTrue(addCommand.equals(addCommand2));
+        assertTrue(addCommand.equals(new AddTagCommand(FRIENDS)));
+
+        assertFalse(addCommand.equals(addCommand2));
+        assertFalse(addCommand.equals(null));
+        assertFalse(addCommand.equals(0));
     }
 
     private class ModelStub implements Model {

--- a/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
@@ -56,7 +56,7 @@ class AddTagCommandTest {
         AddTagCommand addCommand = new AddTagCommand(FRIENDS);
         AddTagCommand addCommand2 = new AddTagCommand(COLLEAGUES);
 
-        assertTrue(addCommand.equals(addCommand2));
+        assertTrue(addCommand.equals(addCommand));
         assertTrue(addCommand.equals(new AddTagCommand(FRIENDS)));
 
         assertFalse(addCommand.equals(addCommand2));

--- a/src/test/java/seedu/contax/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/DeleteTagCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.contax.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.contax.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
@@ -67,5 +69,18 @@ public class DeleteTagCommandTest {
         expectedModel.deleteTag(tagToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        DeleteTagCommand deleteCommand = new DeleteTagCommand(Index.fromZeroBased(0));
+        DeleteTagCommand deleteCommand2 = new DeleteTagCommand(Index.fromZeroBased(1));
+
+        assertTrue(deleteCommand.equals(deleteCommand));
+        assertTrue(deleteCommand.equals(new DeleteTagCommand(Index.fromZeroBased(0))));
+
+        assertFalse(deleteCommand.equals(deleteCommand2));
+        assertFalse(deleteCommand.equals(null));
+        assertFalse(deleteCommand.equals(0));
     }
 }

--- a/src/test/java/seedu/contax/logic/commands/ImportCsvCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ImportCsvCommandTest.java
@@ -57,8 +57,6 @@ public class ImportCsvCommandTest {
                 .withPhone(PERSON2_PHONE).withEmail(PERSON2_EMAIL)
                 .withAddress(PERSON2_ADDRESS).withTags("tag1");
         expectedModel.addPerson(personBuilder2.build());
-        expectedModel.addTag(new Tag("tag1"));
-        expectedModel.addTag(new Tag("tag2"));
         assertCommandSuccess(importCsvCommand, model, ImportCsvCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
@@ -82,9 +80,6 @@ public class ImportCsvCommandTest {
                 .withPhone(PERSON5_PHONE).withEmail(PERSON5_EMAIL)
                 .withAddress(PERSON5_ADDRESS).withTags("tag2", "tag3");
         expectedModel.addPerson(personBuilder5.build());
-        expectedModel.addTag(new Tag("tag1"));
-        expectedModel.addTag(new Tag("tag2"));
-        expectedModel.addTag(new Tag("tag3"));
 
         assertCommandSuccess(importCsvCommand, model, String.format("%s\n%s", ImportCsvCommand.MESSAGE_SUCCESS,
                 String.format(ImportCsvCommand.MESSAGE_SKIPPED_LINES, "3, 4")), expectedModel);
@@ -105,17 +100,12 @@ public class ImportCsvCommandTest {
                 .withPhone(PERSON1_PHONE).withEmail(PERSON1_EMAIL)
                 .withAddress(PERSON1_ADDRESS).withTags("tag1", "tag2");
         model.addPerson(personBuilder1.build());
-        model.addTag(new Tag("tag1"));
-        model.addTag(new Tag("tag2"));
         //Build expecting model with person 1 and 2
         expectedModel.addPerson(personBuilder1.build());
         PersonBuilder personBuilder2 = new PersonBuilder().withName(PERSON2_NAME)
                 .withPhone(PERSON2_PHONE).withEmail(PERSON2_EMAIL)
                 .withAddress(PERSON2_ADDRESS).withTags("tag1");
         expectedModel.addPerson(personBuilder2.build());
-
-        expectedModel.addTag(new Tag("tag1"));
-        expectedModel.addTag(new Tag("tag2"));
 
         assertCommandSuccess(importCsvCommand, model, String.format("%s\n%s", ImportCsvCommand.MESSAGE_SUCCESS,
                 String.format(ImportCsvCommand.MESSAGE_SKIPPED_LINES, "1")), expectedModel);
@@ -146,8 +136,6 @@ public class ImportCsvCommandTest {
                 .withPhone(PERSON2_PHONE).withEmail(PERSON2_EMAIL)
                 .withAddress(PERSON2_ADDRESS).withTags("tag1");
         expectedModel.addPerson(personBuilder2.build());
-        expectedModel.addTag(new Tag("tag1"));
-        expectedModel.addTag(new Tag("tag2"));
 
         assertCommandSuccess(importCsvCommand, model, ImportCsvCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/contax/logic/commands/ImportCsvCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/ImportCsvCommandTest.java
@@ -13,7 +13,6 @@ import seedu.contax.model.Model;
 import seedu.contax.model.ModelManager;
 import seedu.contax.model.Schedule;
 import seedu.contax.model.UserPrefs;
-import seedu.contax.model.tag.Tag;
 import seedu.contax.testutil.ImportCsvObjectBuilder;
 import seedu.contax.testutil.PersonBuilder;
 

--- a/src/test/java/seedu/contax/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/contax/logic/parser/AddressBookParserTest.java
@@ -14,12 +14,14 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.commons.core.index.Index;
 import seedu.contax.logic.commands.AddAppointmentCommand;
 import seedu.contax.logic.commands.AddCommand;
 import seedu.contax.logic.commands.AddTagCommand;
 import seedu.contax.logic.commands.ClearCommand;
 import seedu.contax.logic.commands.DeleteAppointmentCommand;
 import seedu.contax.logic.commands.DeleteCommand;
+import seedu.contax.logic.commands.DeleteTagCommand;
 import seedu.contax.logic.commands.EditCommand;
 import seedu.contax.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.contax.logic.commands.ExitCommand;
@@ -27,6 +29,7 @@ import seedu.contax.logic.commands.FindCommand;
 import seedu.contax.logic.commands.HelpCommand;
 import seedu.contax.logic.commands.ListAppointmentCommand;
 import seedu.contax.logic.commands.ListCommand;
+import seedu.contax.logic.commands.ListTagCommand;
 import seedu.contax.logic.parser.exceptions.ParseException;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.person.NameContainsKeywordsPredicate;
@@ -107,6 +110,20 @@ public class AddressBookParserTest {
         assertEquals(command, new AddTagCommand(tag));
     }
 
+    @Test
+    public void parseCommand_listTag() throws Exception {
+        assertTrue(parser.parseCommand(ListTagCommand.COMMAND_WORD) instanceof ListTagCommand);
+    }
+
+    @Test
+    public void parseCommand_deleteTag() throws Exception {
+        Index firstIndex = Index.fromOneBased(1);
+        String deleteCommand = String.format("%s %s", DeleteTagCommand.COMMAND_WORD, 1);
+        DeleteTagCommand command = (DeleteTagCommand) parser.parseCommand(deleteCommand);
+        assertEquals(command, new DeleteTagCommand(firstIndex));
+    }
+
+    // Appointment related commands
     @Test
     public void parseCommand_addAppointment() throws Exception {
         Appointment appointment = new AppointmentBuilder(APPOINTMENT_ALONE).build();

--- a/src/test/java/seedu/contax/model/AddressBookTest.java
+++ b/src/test/java/seedu/contax/model/AddressBookTest.java
@@ -89,7 +89,8 @@ public class AddressBookTest {
         addressBook.addPerson(BOB);
         addressBook.setPerson(ALICE, CARL);
 
-        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(CARL).withPerson(BOB).build();
+        AddressBook expectedAddressBook =
+                new AddressBookBuilder().withTag(FRIENDS).withPerson(CARL).withPerson(BOB).build();
         assertEquals(expectedAddressBook, addressBook);
     }
 
@@ -138,15 +139,15 @@ public class AddressBookTest {
         addressBook.addPerson(BOB);
         addressBook.removePerson(ALICE);
 
-        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(BOB).build();
+        AddressBook expectedAddressBook = new AddressBookBuilder().withTag(FRIENDS).withPerson(BOB).build();
         assertEquals(expectedAddressBook, addressBook);
     }
 
     @Test
     public void equals() {
         AddressBook refAddressBook = new AddressBook();
-        AddressBook addedPersonAddressBook = new AddressBookBuilder().withPerson(ALICE).withTag(FRIENDS).build();
-        AddressBook otherAddressBook = new AddressBookBuilder().withPerson(ALICE).withTag(FRIENDS).build();
+        AddressBook addedPersonAddressBook = new AddressBookBuilder().withPerson(ALICE).build();
+        AddressBook otherAddressBook = new AddressBookBuilder().withPerson(ALICE).build();
 
         assertTrue(refAddressBook.equals(new AddressBook()));
         assertTrue(refAddressBook.equals(refAddressBook));
@@ -160,8 +161,8 @@ public class AddressBookTest {
     @Test
     public void hashCodeTest() {
         AddressBook refAddressBook = new AddressBook();
-        AddressBook addedPersonAddressBook = new AddressBookBuilder().withPerson(ALICE).withTag(FRIENDS).build();
-        AddressBook otherAddressBook = new AddressBookBuilder().withPerson(ALICE).withTag(FRIENDS).build();
+        AddressBook addedPersonAddressBook = new AddressBookBuilder().withPerson(ALICE).build();
+        AddressBook otherAddressBook = new AddressBookBuilder().withPerson(ALICE).build();
 
         assertEquals(refAddressBook.hashCode(), (new AddressBook()).hashCode());
         assertEquals(refAddressBook.hashCode(), refAddressBook.hashCode());

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -27,12 +27,10 @@ import seedu.contax.commons.core.GuiSettings;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.exceptions.AppointmentNotFoundException;
 import seedu.contax.model.person.NameContainsKeywordsPredicate;
-import seedu.contax.model.person.Person;
 import seedu.contax.model.person.exceptions.PersonNotFoundException;
 import seedu.contax.model.tag.exceptions.TagNotFoundException;
 import seedu.contax.testutil.AddressBookBuilder;
 import seedu.contax.testutil.AppointmentBuilder;
-import seedu.contax.testutil.PersonBuilder;
 import seedu.contax.testutil.ScheduleBuilder;
 
 public class ModelManagerTest {

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -145,6 +145,7 @@ public class ModelManagerTest {
         modelManager.deletePerson(ALICE);
 
         ModelManager expectedModel = new ModelManager();
+        expectedModel.addTag(FRIENDS);
         expectedModel.addPerson(BOB);
         assertEquals(expectedModel, modelManager);
     }
@@ -160,6 +161,7 @@ public class ModelManagerTest {
         modelManager.deletePerson(ALICE);
 
         ModelManager expectedModel = new ModelManager();
+        expectedModel.addTag(FRIENDS);
         expectedModel.addPerson(BOB);
         expectedModel.addAppointment(new AppointmentBuilder(APPOINTMENT_ALICE).withPerson(null).build());
         expectedModel.addAppointment(appointment2);
@@ -186,6 +188,7 @@ public class ModelManagerTest {
         modelManager.setPerson(ALICE, CARL);
 
         ModelManager expectedModel = new ModelManager();
+        expectedModel.addTag(FRIENDS);
         expectedModel.addPerson(CARL);
         expectedModel.addPerson(BOB);
         assertEquals(expectedModel, modelManager);
@@ -202,6 +205,7 @@ public class ModelManagerTest {
         modelManager.setPerson(ALICE, CARL);
 
         ModelManager expectedModel = new ModelManager();
+        expectedModel.addTag(FRIENDS);
         expectedModel.addPerson(CARL);
         expectedModel.addPerson(BOB);
         expectedModel.addAppointment(new AppointmentBuilder(APPOINTMENT_ALICE).withPerson(CARL).build());
@@ -246,25 +250,6 @@ public class ModelManagerTest {
     @Test
     public void deleteTag_tagNotInList_throwsTagNotFoundException() {
         assertThrows(TagNotFoundException.class, () -> modelManager.deleteTag(FAMILY));
-    }
-
-    @Test
-    public void removeTagFromPersons_nullTag_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.deleteTag(null));
-    }
-
-    @Test
-    public void removeTagFromPersons_tagExistsInPerson_success() {
-        modelManager.addPerson(ALICE);
-        modelManager.addTag(FRIENDS);
-
-
-        Person modifiedAlice = new PersonBuilder(ALICE).withTags().build();
-        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(modifiedAlice).build();
-        ModelManager expectedModel = new ModelManager(expectedAddressBook, new Schedule(), new UserPrefs());
-
-        modelManager.deleteTag(FRIENDS);
-        assertEquals(expectedModel, modelManager);
     }
 
     @Test

--- a/src/test/java/seedu/contax/model/person/PersonTest.java
+++ b/src/test/java/seedu/contax/model/person/PersonTest.java
@@ -1,5 +1,6 @@
 package seedu.contax.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
@@ -9,8 +10,11 @@ import static seedu.contax.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.contax.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
+import static seedu.contax.testutil.TypicalPersons.BENSON;
 import static seedu.contax.testutil.TypicalPersons.BOB;
+import static seedu.contax.testutil.TypicalPersons.CARL;
 import static seedu.contax.testutil.TypicalPersons.COLLEAGUES;
+import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,8 +57,30 @@ public class PersonTest {
 
     @Test
     public void withTag() {
-        Person editedAlice = new PersonBuilder(ALICE).withTags("colleagues").build();
-        assertEquals(ALICE.withTag(COLLEAGUES), edite)
+        // Unique tag added to person
+        Person editedAlice = new PersonBuilder(ALICE).withTags("colleagues", "friends").build();
+        assertEquals(ALICE.withTag(COLLEAGUES), editedAlice);
+
+        // Adding a tag that already exists in person
+        assertEquals(BENSON, BENSON.withTag(FRIENDS));
+    }
+
+    @Test
+    public void withoutTag() {
+        Person editedAlice = new PersonBuilder(ALICE).withTags().build();
+        assertEquals(ALICE.withoutTag(FRIENDS), editedAlice);
+    }
+
+    @Test
+    public void hasTag() {
+        // Tag does exist in person
+        assertTrue(ALICE.hasTag(FRIENDS));
+
+        // Tag does not exist in person
+        assertFalse(ALICE.hasTag(COLLEAGUES));
+
+        // Person does not have any tags
+        assertFalse(CARL.hasTag(FRIENDS));
     }
 
     @Test

--- a/src/test/java/seedu/contax/model/person/PersonTest.java
+++ b/src/test/java/seedu/contax/model/person/PersonTest.java
@@ -10,6 +10,7 @@ import static seedu.contax.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
 import static seedu.contax.testutil.TypicalPersons.BOB;
+import static seedu.contax.testutil.TypicalPersons.COLLEAGUES;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +49,12 @@ public class PersonTest {
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSamePerson(editedBob));
+    }
+
+    @Test
+    public void withTag() {
+        Person editedAlice = new PersonBuilder(ALICE).withTags("colleagues").build();
+        assertEquals(ALICE.withTag(COLLEAGUES), edite)
     }
 
     @Test

--- a/src/test/java/seedu/contax/model/tag/UniqueTagListTest.java
+++ b/src/test/java/seedu/contax/model/tag/UniqueTagListTest.java
@@ -61,6 +61,34 @@ class UniqueTagListTest {
     }
 
     @Test
+    public void setTag_uniqueTag_success() {
+        uniqueTagList.add(FAMILY);
+        UniqueTagList expectedUniqueTagList = new UniqueTagList();
+        expectedUniqueTagList.add(CLIENTS);
+
+        uniqueTagList.setTag(FAMILY, CLIENTS);
+        assertEquals(expectedUniqueTagList, uniqueTagList);
+    }
+
+    @Test
+    public void setTag_tagsAreSame_success() {
+        uniqueTagList.add(FAMILY);
+        UniqueTagList expectedUniqueTagList = new UniqueTagList();
+        expectedUniqueTagList.add(FAMILY);
+
+        uniqueTagList.setTag(FAMILY, FAMILY);
+        assertEquals(expectedUniqueTagList, uniqueTagList);
+    }
+
+    @Test
+    public void setTag_duplicateTag_throwsDuplicateTagException() {
+        uniqueTagList.add(FAMILY);
+        uniqueTagList.add(CLIENTS);
+
+        assertThrows(DuplicateTagException.class, () -> uniqueTagList.setTag(FAMILY, CLIENTS));
+    }
+
+    @Test
     public void setTags_duplicateTagList_throwsDuplicateTagException() {
         List<Tag> listWithDuplicateTags = Arrays.asList(CLIENTS, CLIENTS);
         assertThrows(DuplicateTagException.class, () -> uniqueTagList.setTags(listWithDuplicateTags));


### PR DESCRIPTION
# Changes
This PR provides tighter integrity enforcement in the Person-Tag relationship by moving the synchronisation logic from the `Logic` component to the `Model` component. 

# Related Issues
- Fixes #160 