### PR TITLE
Add Chronological Ordering for Appointments

### DIFF
--- a/src/main/java/seedu/contax/logic/Logic.java
+++ b/src/main/java/seedu/contax/logic/Logic.java
@@ -46,6 +46,11 @@ public interface Logic {
     Path getAddressBookFilePath();
 
     /**
+     * Returns the user prefs' schedule file path.
+     */
+    Path getScheduleFilePath();
+
+    /**
      * Returns the user prefs' GUI settings.
      */
     GuiSettings getGuiSettings();

--- a/src/main/java/seedu/contax/logic/LogicManager.java
+++ b/src/main/java/seedu/contax/logic/LogicManager.java
@@ -83,6 +83,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public Path getScheduleFilePath() {
+        return model.getScheduleFilePath();
+    }
+
+    @Override
     public GuiSettings getGuiSettings() {
         return model.getGuiSettings();
     }

--- a/src/main/java/seedu/contax/model/appointment/Appointment.java
+++ b/src/main/java/seedu/contax/model/appointment/Appointment.java
@@ -11,7 +11,7 @@ import seedu.contax.model.person.Person;
 /**
  * Represents an appointment in the schedule.
  */
-public class Appointment {
+public class Appointment implements Comparable<Appointment> {
 
     // Appointment identification fields
     private final StartDateTime startDateTime;
@@ -137,5 +137,10 @@ public class Appointment {
                 + getDuration()
                 + "; Person: "
                 + getPerson();
+    }
+
+    @Override
+    public int compareTo(Appointment o) {
+        return this.getStartDateTime().compareTo(o.getStartDateTime());
     }
 }

--- a/src/main/java/seedu/contax/model/appointment/DisjointAppointmentList.java
+++ b/src/main/java/seedu/contax/model/appointment/DisjointAppointmentList.java
@@ -14,8 +14,11 @@ import seedu.contax.model.appointment.exceptions.OverlappingAppointmentException
 /**
  * A list of appointments that enforces that its elements cannot have overlapping periods and does not allow
  * nulls. This check is performed using {@link Appointment#isOverlapping(Appointment)}, and will be performed
- * upon any modification to the list. Note that {@link #remove(Appointment)} uses Appointment#equals(Object)
- * to find the target appointment to remove.
+ * upon any modification to the list. It also enforces a chronological ordering of the appointments in the
+ * list, done by sorting {@link Appointment#getStartDateTime()} since appointments are disjoint.
+ *
+ * Note that {@link #remove(Appointment)} uses Appointment#equals(Object) to find the target appointment to
+ * remove.
  *
  * Supports a minimal set of list operations.
  */
@@ -46,6 +49,7 @@ public class DisjointAppointmentList implements Iterable<Appointment> {
         }
 
         this.appointments.setAll(appointments);
+        this.appointments.sort(Appointment::compareTo);
     }
 
     /**
@@ -105,6 +109,7 @@ public class DisjointAppointmentList implements Iterable<Appointment> {
         }
 
         appointments.add(target);
+        shiftAppointmentToPosition(appointments.size() - 1);
     }
 
     /**
@@ -132,6 +137,7 @@ public class DisjointAppointmentList implements Iterable<Appointment> {
         }
 
         appointments.set(indexOfTarget, newAppointment);
+        shiftAppointmentToPosition(indexOfTarget);
     }
 
     /**
@@ -201,5 +207,40 @@ public class DisjointAppointmentList implements Iterable<Appointment> {
             }
         }
         return true;
+    }
+
+    /**
+     * Performs the shifting operation in insertion sort, omitting the insert into list component of
+     * insertion sort, and shifts the appointment at the given {@code index} into its sorted position.
+     * Note that this function may only be called if only the given appointment at {@code index} is out
+     * of position.
+     *
+     * @param index The appointment to shift into place.
+     */
+    private void shiftAppointmentToPosition(int index) {
+        if (index < 0 || index >= appointments.size()) {
+            return;
+        }
+        Appointment target = appointments.get(index);
+        int otherIndex = index;
+
+        // Determine direction
+        if (index - 1 >= 0 && target.compareTo(appointments.get(index - 1)) < 0) {
+            // target < index - 1, shift left
+            otherIndex = index - 1;
+            while (otherIndex >= 0 && target.compareTo(appointments.get(otherIndex)) < 0) {
+                appointments.set(otherIndex + 1, appointments.get(otherIndex)); // Right Shift
+                otherIndex--;
+            }
+            appointments.set(otherIndex + 1, target);
+        } else if (index + 1 < appointments.size() && target.compareTo(appointments.get(index + 1)) > 0) {
+            // target > index + 1
+            otherIndex = index + 1;
+            while (otherIndex < appointments.size() && target.compareTo(appointments.get(otherIndex)) > 0) {
+                appointments.set(otherIndex - 1, appointments.get(otherIndex)); // Left Shift
+                otherIndex++;
+            }
+            appointments.set(otherIndex - 1, target);
+        }
     }
 }

--- a/src/main/java/seedu/contax/model/appointment/DisjointAppointmentList.java
+++ b/src/main/java/seedu/contax/model/appointment/DisjointAppointmentList.java
@@ -215,12 +215,11 @@ public class DisjointAppointmentList implements Iterable<Appointment> {
      * Note that this function may only be called if only the given appointment at {@code index} is out
      * of position.
      *
-     * @param index The appointment to shift into place.
+     * @param index The appointment to shift into place. This must be a valid index in the appointments list.
      */
     private void shiftAppointmentToPosition(int index) {
-        if (index < 0 || index >= appointments.size()) {
-            return;
-        }
+        assert (index >= 0 && index < appointments.size());
+
         Appointment target = appointments.get(index);
         int otherIndex = index;
 

--- a/src/main/java/seedu/contax/model/appointment/StartDateTime.java
+++ b/src/main/java/seedu/contax/model/appointment/StartDateTime.java
@@ -9,7 +9,7 @@ import java.time.format.DateTimeFormatter;
  * Represents an {@link Appointment}'s starting DateTime in the schedule.
  * Guarantees: Immutable; is always a valid {@link LocalDateTime}; Seconds field is always zeroed.
  */
-public class StartDateTime {
+public class StartDateTime implements Comparable<StartDateTime> {
     public static final String DATETIME_FORMAT = "dd-MM-yyyy HH:mm";
     public static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern(DATETIME_FORMAT);
     public static final String MESSAGE_CONSTRAINTS = "DateTime has to be valid";
@@ -41,5 +41,10 @@ public class StartDateTime {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(StartDateTime o) {
+        return this.value.compareTo(o.value);
     }
 }

--- a/src/main/java/seedu/contax/ui/AppointmentCard.java
+++ b/src/main/java/seedu/contax/ui/AppointmentCard.java
@@ -39,6 +39,8 @@ public class AppointmentCard extends UiPart<Region> {
     private Label personName;
     @FXML
     private Label personAddress;
+    @FXML
+    private Label withLabel;
 
     /**
      * Creates a {@code AppointmentCard} with the given {@code Appointment} and index to display.
@@ -59,10 +61,12 @@ public class AppointmentCard extends UiPart<Region> {
         endTime.setText(endDateTime.format(TIME_FORMATTER));
 
         if (appointmentModel.getPerson() != null) {
+            withLabel.setVisible(true);
             Person p = appointmentModel.getPerson();
             personName.setText(p.getName().fullName);
             personAddress.setText(p.getAddress().value);
         } else {
+            withLabel.setVisible(false);
             personName.setText("");
             personAddress.setText("");
         }

--- a/src/main/java/seedu/contax/ui/MainWindow.java
+++ b/src/main/java/seedu/contax/ui/MainWindow.java
@@ -38,6 +38,7 @@ public class MainWindow extends UiPart<Stage> {
     private TagListPanel tagListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+    private StatusBarFooter statusBarFooter;
 
     private OnboardingPrompt onboardingPrompt;
     // Flag indicating the type of model currently being displayed in the contentList
@@ -123,6 +124,9 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
+        statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
+
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         appointmentListPanel = new AppointmentListPanel(logic.getAppointmentList());
         tagListPanel = new TagListPanel(logic.getTagList());
@@ -130,9 +134,6 @@ public class MainWindow extends UiPart<Stage> {
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
-
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
-        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
@@ -174,6 +175,21 @@ public class MainWindow extends UiPart<Stage> {
             contentListPanelPlaceholder.getChildren().add(appointmentListPanel.getRoot());
         } else if (contentType == GuiListContentType.TAG) {
             contentListPanelPlaceholder.getChildren().add(tagListPanel.getRoot());
+        }
+        changeFooterContentType(contentType);
+    }
+
+    /**
+     * Changes the footer save file location path to the corresponding file path for the type of model being
+     * displayed in the content list.
+     *
+     * @param contentType The type of content the UI is currently displaying.
+     */
+    private void changeFooterContentType(GuiListContentType contentType) {
+        if (contentType == GuiListContentType.PERSON || contentType == GuiListContentType.TAG) {
+            statusBarFooter.setSaveLocation(logic.getAddressBookFilePath());
+        } else if (contentType == GuiListContentType.APPOINTMENT) {
+            statusBarFooter.setSaveLocation(logic.getScheduleFilePath());
         }
     }
 

--- a/src/main/java/seedu/contax/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/contax/ui/StatusBarFooter.java
@@ -22,6 +22,15 @@ public class StatusBarFooter extends UiPart<Region> {
      */
     public StatusBarFooter(Path saveLocation) {
         super(FXML);
+        setSaveLocation(saveLocation);
+    }
+
+    /**
+     * Sets the content of the {@code saveLocationStatus} label.
+     *
+     * @param saveLocation The path that should be displayed in the footer.
+     */
+    public void setSaveLocation(Path saveLocation) {
         saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
     }
 

--- a/src/main/resources/view/AppointmentListCard.fxml
+++ b/src/main/resources/view/AppointmentListCard.fxml
@@ -45,7 +45,7 @@
             <Insets left="32" />
           </padding>
           <VBox alignment="CENTER_LEFT" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-            <Label styleClass="cell_big_light_label" text="With" />
+            <Label fx:id="withLabel" styleClass="cell_big_light_label" text="With" />
             <Label fx:id="personName" styleClass="cell_small_label" text="\$person name" />
             <Label fx:id="personAddress" styleClass="cell_small_label" text="\$person address" />
           </VBox>

--- a/src/test/java/seedu/contax/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/contax/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.contax.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static seedu.contax.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.contax.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.contax.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -123,6 +124,13 @@ public class LogicManagerTest {
     @Test
     public void getAppointmentList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getAppointmentList().remove(0));
+    }
+
+    @Test
+    public void userPrefGetters_noInput_notNull() {
+        assertNotNull(logic.getAddressBookFilePath());
+        assertNotNull(logic.getScheduleFilePath());
+        assertNotNull(logic.getGuiSettings());
     }
 
     /**

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -361,8 +361,8 @@ public class ModelManagerTest {
         modelManager.addAppointment(APPOINTMENT_EXTRA);
 
         modelManager.updateFilteredAppointmentList(appointment -> !appointment.equals(APPOINTMENT_ALONE));
-        assertEquals(APPOINTMENT_ALICE, modelManager.getFilteredAppointmentList().get(0));
-        assertEquals(APPOINTMENT_EXTRA, modelManager.getFilteredAppointmentList().get(1));
+        assertEquals(APPOINTMENT_EXTRA, modelManager.getFilteredAppointmentList().get(0));
+        assertEquals(APPOINTMENT_ALICE, modelManager.getFilteredAppointmentList().get(1));
     }
 
     @Test

--- a/src/test/java/seedu/contax/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/contax/model/appointment/AppointmentTest.java
@@ -176,4 +176,21 @@ public class AppointmentTest {
                 + appointment.getPerson(),
                 appointment.toString());
     }
+
+    @Test
+    public void comparisonTest() {
+        Appointment refAppointment = new AppointmentBuilder()
+                .withStartDateTime(LocalDateTime.parse("2020-10-30T12:34:00")).build();
+        Appointment appointmentBefore = new AppointmentBuilder()
+                .withStartDateTime(LocalDateTime.parse("2020-10-30T12:33:00")).build();
+        Appointment appointmentAfter = new AppointmentBuilder()
+                .withStartDateTime(LocalDateTime.parse("2020-10-30T12:35:00")).build();
+        Appointment appointmentDifferentSeconds = new AppointmentBuilder()
+                .withStartDateTime(LocalDateTime.parse("2020-10-30T12:34:54")).build();
+
+        assertEquals(0, refAppointment.compareTo(refAppointment));
+        assertEquals(0, refAppointment.compareTo(appointmentDifferentSeconds));
+        assertEquals(1, refAppointment.compareTo(appointmentBefore));
+        assertEquals(-1, refAppointment.compareTo(appointmentAfter));
+    }
 }

--- a/src/test/java/seedu/contax/model/appointment/DisjointAppointmentListTest.java
+++ b/src/test/java/seedu/contax/model/appointment/DisjointAppointmentListTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_ALICE;
 import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_ALONE;
-import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_EXTRA;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/test/java/seedu/contax/model/appointment/DisjointAppointmentListTest.java
+++ b/src/test/java/seedu/contax/model/appointment/DisjointAppointmentListTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_ALICE;
 import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_ALONE;
+import static seedu.contax.testutil.TypicalAppointments.APPOINTMENT_EXTRA;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -95,6 +97,26 @@ public class DisjointAppointmentListTest {
     }
 
     @Test
+    public void add_unsortedNewAppointment_successSortsPosition() {
+        LocalDateTime baseDateTime = APPOINTMENT_ALONE.getStartDateTime().value;
+        appointmentList.add(APPOINTMENT_ALONE);
+
+        Appointment beforeAppointment = new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(2)).build();
+        Appointment afterAppointment = new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.plusDays(2)).build();
+
+        appointmentList.add(beforeAppointment);
+        assertEquals(beforeAppointment, appointmentList.asUnmodifiableObservableList().get(0));
+        assertEquals(APPOINTMENT_ALONE, appointmentList.asUnmodifiableObservableList().get(1));
+
+        appointmentList.add(afterAppointment);
+        assertEquals(beforeAppointment, appointmentList.asUnmodifiableObservableList().get(0));
+        assertEquals(APPOINTMENT_ALONE, appointmentList.asUnmodifiableObservableList().get(1));
+        assertEquals(afterAppointment, appointmentList.asUnmodifiableObservableList().get(2));
+    }
+
+    @Test
     public void setAppointment_nullTargetAppointment_throwsNullPointerException() {
         assertThrows(NullPointerException.class, ()
             -> appointmentList.setAppointment(null, APPOINTMENT_ALICE));
@@ -148,6 +170,37 @@ public class DisjointAppointmentListTest {
     }
 
     @Test
+    public void setAppointment_editedAppointmentDisjointDifferentOrdering_successSortsPosition() {
+        LocalDateTime baseDateTime = APPOINTMENT_ALONE.getStartDateTime().value;
+        Appointment modifiedAloneAppointment = new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(1)).build();
+
+        appointmentList.add(modifiedAloneAppointment);
+        appointmentList.add(APPOINTMENT_ALONE);
+
+        Appointment beforeAppointment = new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withName("Another Meeting")
+                .withStartDateTime(baseDateTime.minusDays(2)).build();
+        Appointment afterAppointment = new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withName("Another Meeting")
+                .withStartDateTime(baseDateTime.plusDays(2)).build();
+
+        appointmentList.setAppointment(APPOINTMENT_ALONE, beforeAppointment);
+        assertEquals(beforeAppointment, appointmentList.asUnmodifiableObservableList().get(0));
+        assertEquals(modifiedAloneAppointment, appointmentList.asUnmodifiableObservableList().get(1));
+
+        appointmentList.setAppointment(beforeAppointment, afterAppointment);
+        assertEquals(modifiedAloneAppointment, appointmentList.asUnmodifiableObservableList().get(0));
+        assertEquals(afterAppointment, appointmentList.asUnmodifiableObservableList().get(1));
+
+        appointmentList.add(beforeAppointment);
+        appointmentList.setAppointment(modifiedAloneAppointment, modifiedAloneAppointment);
+        assertEquals(beforeAppointment, appointmentList.asUnmodifiableObservableList().get(0));
+        assertEquals(modifiedAloneAppointment, appointmentList.asUnmodifiableObservableList().get(1));
+        assertEquals(afterAppointment, appointmentList.asUnmodifiableObservableList().get(2));
+    }
+
+    @Test
     public void setAppointment_editedAppointmentOverlaps_throwsOverlappingAppointmentException() {
         Appointment disjointAppointment = new AppointmentBuilder(APPOINTMENT_ALICE)
                 .withName("Another Meeting")
@@ -188,6 +241,31 @@ public class DisjointAppointmentListTest {
         appointmentList.setAppointments(appointmentArrayList);
 
         DisjointAppointmentList expectedAppointmentList = new DisjointAppointmentList();
+        expectedAppointmentList.add(APPOINTMENT_ALONE);
+        assertEquals(expectedAppointmentList, appointmentList);
+    }
+
+    @Test
+    public void setAppointments_unsortedList_sortsListUponSetting() {
+        appointmentList.add(APPOINTMENT_ALICE);
+        List<Appointment> appointmentArrayList = new ArrayList<>();
+        LocalDateTime baseDateTime = APPOINTMENT_ALONE.getStartDateTime().value;
+        appointmentArrayList.add(APPOINTMENT_ALONE);
+        appointmentArrayList.add(new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(1)).build());
+        appointmentArrayList.add(new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(2)).build());
+        appointmentArrayList.add(new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(3)).build());
+        appointmentList.setAppointments(appointmentArrayList);
+
+        DisjointAppointmentList expectedAppointmentList = new DisjointAppointmentList();
+        expectedAppointmentList.add(new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(3)).build());
+        expectedAppointmentList.add(new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(2)).build());
+        expectedAppointmentList.add(new AppointmentBuilder(APPOINTMENT_ALONE)
+                .withStartDateTime(baseDateTime.minusDays(1)).build());
         expectedAppointmentList.add(APPOINTMENT_ALONE);
         assertEquals(expectedAppointmentList, appointmentList);
     }

--- a/src/test/java/seedu/contax/model/appointment/DisjointAppointmentListTest.java
+++ b/src/test/java/seedu/contax/model/appointment/DisjointAppointmentListTest.java
@@ -197,6 +197,11 @@ public class DisjointAppointmentListTest {
         assertEquals(beforeAppointment, appointmentList.asUnmodifiableObservableList().get(0));
         assertEquals(modifiedAloneAppointment, appointmentList.asUnmodifiableObservableList().get(1));
         assertEquals(afterAppointment, appointmentList.asUnmodifiableObservableList().get(2));
+
+        appointmentList.setAppointment(afterAppointment, afterAppointment);
+        assertEquals(beforeAppointment, appointmentList.asUnmodifiableObservableList().get(0));
+        assertEquals(modifiedAloneAppointment, appointmentList.asUnmodifiableObservableList().get(1));
+        assertEquals(afterAppointment, appointmentList.asUnmodifiableObservableList().get(2));
     }
 
     @Test

--- a/src/test/java/seedu/contax/model/appointment/StartDateTimeTest.java
+++ b/src/test/java/seedu/contax/model/appointment/StartDateTimeTest.java
@@ -58,4 +58,17 @@ public class StartDateTimeTest {
         assertEquals(reference.hashCode(), new StartDateTime(referenceTime1).hashCode());
         assertNotEquals(reference.hashCode(), new StartDateTime(referenceTime2).hashCode());
     }
+
+    @Test
+    public void comparisonTest() {
+        StartDateTime refTime = new StartDateTime(LocalDateTime.parse("2020-10-30T12:34:00"));
+        StartDateTime timeBefore = new StartDateTime(LocalDateTime.parse("2020-10-30T12:33:00"));
+        StartDateTime timeAfter = new StartDateTime(LocalDateTime.parse("2020-10-30T12:35:00"));
+        StartDateTime refTimeDifferentSeconds = new StartDateTime(LocalDateTime.parse("2020-10-30T12:34:54"));
+
+        assertEquals(0, refTime.compareTo(refTime));
+        assertEquals(0, refTime.compareTo(refTimeDifferentSeconds));
+        assertEquals(1, refTime.compareTo(timeBefore));
+        assertEquals(-1, refTime.compareTo(timeAfter));
+    }
 }


### PR DESCRIPTION
## Changes
This PR modifies the `DisjointAppointmentList` class to maintain a chronological ordering for appointments, and should seamlessly propagate to all components in the schedule subsystem that depend on it.

## Important Note
- Test Cases not written to take chronological ordering into account might fail after this PR is merged

## Related Issues
- Closes #167 