### PR TITLE
Fix NullPointerException in ModelManager

### DIFF
--- a/src/main/java/seedu/contax/model/ModelManager.java
+++ b/src/main/java/seedu/contax/model/ModelManager.java
@@ -129,7 +129,7 @@ public class ModelManager implements Model {
         // any modification to the list.
         List<Appointment> oldAppointments = new ArrayList<>(
                 schedule.getAppointmentList()
-                        .filtered(appointment -> appointment.getPerson().equals(target)));
+                        .filtered(appointment -> target.equals(appointment.getPerson())));
         oldAppointments.forEach(appointment -> {
             setAppointment(appointment, appointment.withPerson(null));
         });
@@ -152,7 +152,7 @@ public class ModelManager implements Model {
         // any modification to the list.
         List<Appointment> oldAppointments = new ArrayList<>(
                 schedule.getAppointmentList()
-                        .filtered(appointment -> appointment.getPerson().equals(target)));
+                        .filtered(appointment -> target.equals(appointment.getPerson())));
 
         oldAppointments.forEach(appointment -> {
             setAppointment(appointment, appointment.withPerson(editedPerson));

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -155,7 +155,8 @@ public class ModelManagerTest {
         modelManager.addPerson(ALICE);
         modelManager.addPerson(BOB);
         modelManager.addAppointment(APPOINTMENT_ALICE);
-        Appointment appointment2 = new AppointmentBuilder(APPOINTMENT_ALONE).withPerson(BOB).build();
+        modelManager.addAppointment(APPOINTMENT_ALONE);
+        Appointment appointment2 = new AppointmentBuilder(APPOINTMENT_EXTRA).withPerson(BOB).build();
         modelManager.addAppointment(appointment2);
 
         modelManager.deletePerson(ALICE);
@@ -163,6 +164,7 @@ public class ModelManagerTest {
         ModelManager expectedModel = new ModelManager();
         expectedModel.addTag(FRIENDS);
         expectedModel.addPerson(BOB);
+        expectedModel.addAppointment(APPOINTMENT_ALONE);
         expectedModel.addAppointment(new AppointmentBuilder(APPOINTMENT_ALICE).withPerson(null).build());
         expectedModel.addAppointment(appointment2);
         assertEquals(expectedModel, modelManager);
@@ -198,8 +200,9 @@ public class ModelManagerTest {
     public void setPerson_personInAddressBookHasAppointments_success() {
         modelManager.addPerson(ALICE);
         modelManager.addPerson(BOB);
+        modelManager.addAppointment(APPOINTMENT_ALONE);
         modelManager.addAppointment(APPOINTMENT_ALICE);
-        Appointment appointment2 = new AppointmentBuilder(APPOINTMENT_ALONE).withPerson(BOB).build();
+        Appointment appointment2 = new AppointmentBuilder(APPOINTMENT_EXTRA).withPerson(BOB).build();
         modelManager.addAppointment(appointment2);
 
         modelManager.setPerson(ALICE, CARL);
@@ -208,6 +211,7 @@ public class ModelManagerTest {
         expectedModel.addTag(FRIENDS);
         expectedModel.addPerson(CARL);
         expectedModel.addPerson(BOB);
+        expectedModel.addAppointment(APPOINTMENT_ALONE);
         expectedModel.addAppointment(new AppointmentBuilder(APPOINTMENT_ALICE).withPerson(CARL).build());
         expectedModel.addAppointment(appointment2);
         assertEquals(expectedModel, modelManager);


### PR DESCRIPTION
## Changes
This PR directly addresses issue #190, which was caused by the appointments cascading functionality in `ModelManager`. Test cases were also updated to pick up the issue to ensure that it does not occur.

## Related Issues
- Closes #190