### PR TITLE
Change Schedule Inflation to be More Forgiving

### DIFF
--- a/src/main/java/seedu/contax/storage/JsonSerializableSchedule.java
+++ b/src/main/java/seedu/contax/storage/JsonSerializableSchedule.java
@@ -2,12 +2,14 @@ package seedu.contax.storage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.commons.exceptions.IllegalValueException;
 import seedu.contax.model.ReadOnlyAddressBook;
 import seedu.contax.model.ReadOnlySchedule;
@@ -23,6 +25,9 @@ class JsonSerializableSchedule {
 
     public static final String MESSAGE_OVERLAPPING_APPOINTMENT =
             "Schedule contains overlapping appointments.";
+
+    private static final Logger LOGGER = LogsCenter.getLogger(JsonSerializableSchedule.class);
+    private static final String MESSAGE_SKIP_APPOINTMENT = "Appointment cannot be inflated, skipping record";
 
     private final List<JsonAdaptedAppointment> appointments = new ArrayList<>();
 
@@ -54,11 +59,13 @@ class JsonSerializableSchedule {
     public Schedule toModelType(ReadOnlyAddressBook addressBook) throws IllegalValueException {
         Schedule schedule = new Schedule();
         for (JsonAdaptedAppointment jsonAdaptedAppointment : appointments) {
-            Appointment appointment = jsonAdaptedAppointment.toModelType(addressBook);
             try {
+                Appointment appointment = jsonAdaptedAppointment.toModelType(addressBook);
                 schedule.addAppointment(appointment);
             } catch (OverlappingAppointmentException ex) {
                 throw new IllegalValueException(MESSAGE_OVERLAPPING_APPOINTMENT);
+            } catch (IllegalValueException ex) {
+                LOGGER.info(MESSAGE_SKIP_APPOINTMENT);
             }
         }
         return schedule;

--- a/src/test/data/JsonScheduleStorageTest/overlappingAppointmentSchedule.json
+++ b/src/test/data/JsonScheduleStorageTest/overlappingAppointmentSchedule.json
@@ -1,0 +1,14 @@
+{
+  "appointments": [
+    {
+      "name": "Valid appointment",
+      "startDateTime": "2022-11-11T12:34:00",
+      "duration": 10
+    },
+    {
+      "name": "But It Overlaps",
+      "startDateTime": "2022-11-11T12:36:00",
+      "duration": 10
+    }
+  ]
+}

--- a/src/test/data/JsonSerializableScheduleTest/invalidAppointmentSchedule.json
+++ b/src/test/data/JsonSerializableScheduleTest/invalidAppointmentSchedule.json
@@ -4,6 +4,17 @@
       "name": "Meeting With forbidden character?",
       "startDateTime": "2022-11-11T12:34:00",
       "duration": 10
+    },
+    {
+      "name": "First meeting with alice",
+      "startDateTime": "2022-11-20T10:25:00",
+      "duration": 30,
+      "person": "Alice Pauline"
+    },
+    {
+      "name": "Do some work alone",
+      "startDateTime": "2022-10-07T22:50:00",
+      "duration": 60
     }
   ]
 }

--- a/src/test/java/seedu/contax/storage/JsonScheduleStorageTest.java
+++ b/src/test/java/seedu/contax/storage/JsonScheduleStorageTest.java
@@ -89,6 +89,12 @@ public class JsonScheduleStorageTest {
     }
 
     @Test
+    public void readSchedule_overlappingAppointment_throwsDataConversionException() {
+        assertThrows(DataConversionException.class, ()
+            -> readSchedule("overlappingAppointmentSchedule.json", GLOBAL_ADDRESSBOOK));
+    }
+
+    @Test
     public void readAddressBook_validAppointments_success() throws Exception {
         Optional<ReadOnlySchedule> schedule = readSchedule("validAppointmentSchedule.json",
                 GLOBAL_ADDRESSBOOK);

--- a/src/test/java/seedu/contax/storage/JsonScheduleStorageTest.java
+++ b/src/test/java/seedu/contax/storage/JsonScheduleStorageTest.java
@@ -12,6 +12,7 @@ import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import seedu.contax.model.ReadOnlySchedule;
 import seedu.contax.model.Schedule;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.testutil.AppointmentBuilder;
+import seedu.contax.testutil.ScheduleBuilder;
 
 public class JsonScheduleStorageTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test",
@@ -66,15 +68,24 @@ public class JsonScheduleStorageTest {
     }
 
     @Test
-    public void readSchedule_invalidAppointment_throwDataConversionException() {
-        assertThrows(DataConversionException.class, ()
-            -> readSchedule("invalidAppointmentSchedule.json", GLOBAL_ADDRESSBOOK));
+    public void readSchedule_invalidAppointment_recordSkipped() throws Exception {
+        ReadOnlySchedule schedule =
+                readSchedule("invalidAppointmentSchedule.json", GLOBAL_ADDRESSBOOK).get();
+        assertEquals(0, schedule.getAppointmentList().size());
     }
 
     @Test
-    public void readAddressBook_invalidAndValidAppointment_throwDataConversionException() {
-        assertThrows(DataConversionException.class, ()
-            -> readSchedule("invalidAndValidAppointmentSchedule.json", GLOBAL_ADDRESSBOOK));
+    public void readAddressBook_invalidAndValidAppointment_recordSkipped() throws Exception {
+        ReadOnlySchedule schedule =
+                readSchedule("invalidAndValidAppointmentSchedule.json", GLOBAL_ADDRESSBOOK).get();
+        Appointment expectedAppointment = new AppointmentBuilder()
+                .withName("Valid appointment")
+                .withStartDateTime(LocalDateTime.parse("2022-11-11T12:34"))
+                .withDuration(10)
+                .build();
+        Schedule expectedSchedule = new ScheduleBuilder().withAppointment(expectedAppointment).build();
+
+        assertEquals(schedule, expectedSchedule);
     }
 
     @Test

--- a/src/test/java/seedu/contax/storage/JsonSerializableScheduleTest.java
+++ b/src/test/java/seedu/contax/storage/JsonSerializableScheduleTest.java
@@ -37,10 +37,11 @@ public class JsonSerializableScheduleTest {
     }
 
     @Test
-    public void toModelType_invalidAppointmentFile_throwsIllegalValueException() throws Exception {
+    public void toModelType_invalidAppointmentFile_recordSkipped() throws Exception {
         JsonSerializableSchedule dataFromFile = JsonUtil.readJsonFile(INVALID_APPOINTMENT_FILE,
                 JsonSerializableSchedule.class).get();
-        assertThrows(IllegalValueException.class, () -> dataFromFile.toModelType(GLOBAL_ADDRESSBOOK));
+        Schedule schedule = dataFromFile.toModelType(GLOBAL_ADDRESSBOOK);
+        assertEquals(TypicalAppointments.getTypicalSchedule(), schedule);
     }
 
     @Test


### PR DESCRIPTION
## Change
This is a minor PR fix to allow valid appointments to be loaded even if there exists some invalid appointments in the data file. Test cases were updated to reflect this change.

## Related Issues
- Closes #195 