### PR TITLE
Feature - Add Natural Date and Time Parsing

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -72,20 +72,28 @@ Broadly speaking, ContaX consists of an *Address Book* for managing Contacts, an
 
 **:information_source: This section details the format(s) that date and time inputs are expected to be in.**<br>
 
-* All date inputs must conform to the following format: `dd-mm-yyyy`.
+* All date inputs must conform to one of the following formats:
+  * `dd-mm-yyyy`
+  * `dd/mm/yyyy`
+  * `dd MMM yyyy` with the date components appearing in any order
 
 | Field | Description |
 | - | - |
 | `dd` | Day of the month. |
 | `mm` | Numerical representation of the month, from `1` to `12`. |
+| `MMM` | Textual representation of the month, such as `oct` or `october`. |
 | `yyyy` | Year in the full 4-digit format. |
 
-* All time inputs must conform to the following format: `hh:mm`
+* All time inputs must conform to one of the following formats:
+  * `hh:mm`
+  * `HH:mm aa`
 
 | Field | Description |
 | - | - |
 | `hh` | Hour of the day, in 24-hour format. |
+| `HH` | Hour of the day, in 12-hour format. |
 | `mm` | Minute of the hour, from `00` to `59`. |
+| `aa` | Either `am` or `pm`, case-insensitive. |
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,8 +85,8 @@ Broadly speaking, ContaX consists of an *Address Book* for managing Contacts, an
 | `yyyy` | Year in the full 4-digit format. |
 
 * All time inputs must conform to one of the following formats:
-  * `hh:mm`
-  * `HH:mm aa`
+  * The 24-hour format `hh:mm` or `hh-mm`
+  * The 12-hour format `HH:mm aa` or `HH-mm aa`. The whitespace between the numeric fields and `am/pm` field can be omitted.
 
 | Field | Description |
 | - | - |

--- a/src/main/java/seedu/contax/commons/util/DateUtil.java
+++ b/src/main/java/seedu/contax/commons/util/DateUtil.java
@@ -5,20 +5,20 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
+import seedu.contax.commons.util.datetimeparser.DateParser;
+import seedu.contax.commons.util.datetimeparser.TimeParser;
+
 /**
- * Provides parsing services for dates and times used in the application.
+ * Provides helper methods for working with date and time objects.
+ * Serves as a facade for date and time parsing services.
  */
 public class DateUtil {
 
-    public static final String DATE_PATTERN = "dd-MM-yyyy";
-    public static final String TIME_PATTERN = "HH:mm";
-
     /**
      * Parses a date input string to a {@code LocalDate} object.
+     * See {@link DateParser#parseDate(String)} for detailed information on accepted formats.
      *
      * @param input The input date string to parse.
      * @return An Optional container that contains a LocalDate object if parsing was successful, or an empty
@@ -26,17 +26,12 @@ public class DateUtil {
      */
     public static Optional<LocalDate> parseDate(String input) {
         requireNonNull(input);
-
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
-        try {
-            return Optional.ofNullable(LocalDate.parse(input, dateFormatter));
-        } catch (DateTimeParseException ex) {
-            return Optional.empty();
-        }
+        return DateParser.parseDate(input);
     }
 
     /**
      * Parses a time input string to a {@code LocalTime} object.
+     * See {@link TimeParser#parseTime(String)} for detailed information on accepted formats.
      *
      * @param input The input time string to parse.
      * @return An Optional container that contains a LocalTime object if parsing was successful, or an empty
@@ -44,13 +39,7 @@ public class DateUtil {
      */
     public static Optional<LocalTime> parseTime(String input) {
         requireNonNull(input);
-
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(TIME_PATTERN);
-        try {
-            return Optional.of(LocalTime.parse(input, timeFormatter));
-        } catch (DateTimeParseException ex) {
-            return Optional.empty();
-        }
+        return TimeParser.parseTime(input);
     }
 
     /**

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/DateParser.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/DateParser.java
@@ -1,0 +1,107 @@
+package seedu.contax.commons.util.datetimeparser;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+/**
+ * Provides parsing services for date inputs used in the application.
+ */
+public class DateParser {
+    public static final String DATE_PATTERN = "dd-MM-yyyy";
+
+    /**
+     * Parses a date input string to a {@code LocalDate} object.
+     *
+     * @param input The input date string to parse.
+     * @return An Optional container that contains a LocalDate object if parsing was successful, or an empty
+     *         Optional container if parsing was unsuccessful.
+     */
+    public static Optional<LocalDate> parseDate(String input) {
+        requireNonNull(input);
+
+        return matchStandardFormat(input).flatMap(DateParser::parseStandardFormat)
+            .or(() -> matchNaturalFormat(input).flatMap(DateParser::parseNaturalFormat));
+    }
+
+    /**
+     * Returns a {@link Matcher} object if the input is in the standard date format, contained in an
+     * {@code Optional}, and an empty {@code Optional} otherwise.
+     *
+     * @param input The input date string to match.
+     * @return A {@code Matcher} object in an Optional container if the supplied input matches, or an empty
+     *         optional otherwise.
+     */
+    private static Optional<Matcher> matchStandardFormat(String input) {
+        Matcher match = DateParserPatternProvider.STANDARD_DATE_PATTERN.matcher(input);
+        if (!match.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(match);
+    }
+
+    /**
+     * Parses a standard date format match into a {@link LocalDate} object.
+     *
+     * @param match The match object generated from matching an input string against
+     *              {@link DateParserPatternProvider#STANDARD_DATE_PATTERN}.
+     * @return A {@code LocalDate} object contained in an {@code Optional} if the input is valid, or an
+     *         empty {@code Optional} otherwise.
+     */
+    private static Optional<LocalDate> parseStandardFormat(Matcher match) {
+        try {
+            int day = Integer.parseInt(match.group(1));
+            int month = Integer.parseInt(match.group(2));
+            int year = Integer.parseInt(match.group(3));
+            return Optional.of(LocalDate.of(year, month, day));
+        } catch (NumberFormatException | DateTimeException ex) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns a {@link Matcher} object if the input matches a natural date format, contained in an
+     * {@code Optional}, and an empty {@code Optional} otherwise.
+     * See {@link DateParserPatternProvider#NATURAL_DATE_PATTERN} for more details on the valid natural
+     * date patterns.
+     *
+     * @param input The input date string to match.
+     * @return A {@code Matcher} object in an Optional container if the supplied input matches, or an empty
+     *         optional otherwise.
+     */
+    private static Optional<Matcher> matchNaturalFormat(String input) {
+        final String paddedLowerCaseInput = " " + input.toLowerCase() + " ";
+        Matcher match = DateParserPatternProvider.NATURAL_DATE_PATTERN.matcher(paddedLowerCaseInput);
+        if (!match.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(match);
+    }
+
+    /**
+     * Parses a natural date format match into a {@link LocalDate} object.
+     *
+     * @param match The match object generated from matching an input string against
+     *              {@link DateParserPatternProvider#NATURAL_DATE_PATTERN}.
+     * @return A {@code LocalDate} object contained in an {@code Optional} if the input is valid, or an
+     *         empty {@code Optional} otherwise.
+     */
+    private static Optional<LocalDate> parseNaturalFormat(Matcher match) {
+        try {
+            int day = Integer.parseInt(match.group(1));
+            int month = DateParserPatternProvider.monthStringToDecimal(match.group(2));
+            int year = Integer.parseInt(match.group(3));
+
+            if (month < 1) {
+                return Optional.empty();
+            }
+
+            return Optional.of(LocalDate.of(year, month, day));
+        } catch (NumberFormatException | DateTimeException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/DateParser.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/DateParser.java
@@ -11,7 +11,6 @@ import java.util.regex.Matcher;
  * Provides parsing services for date inputs used in the application.
  */
 public class DateParser {
-    public static final String DATE_PATTERN = "dd-MM-yyyy";
 
     /**
      * Parses a date input string to a {@code LocalDate} object.

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/DateParserPatternProvider.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/DateParserPatternProvider.java
@@ -1,0 +1,57 @@
+package seedu.contax.commons.util.datetimeparser;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Provides commonly used constants for parsing dates. This class is package-private and is only visible to
+ * the {@code datetimeparser} package.
+ */
+class DateParserPatternProvider {
+
+    // Intermediate parts for natural human-readable dates
+    private static final String[] MONTH_STRINGS = new String[] {
+        "january", "february", "march", "april", "may", "june", "july", "august", "september", "october",
+        "november", "december", "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov",
+        "dec"
+    };
+    private static final String COMBINED_MONTH_STRING = String.join("|", MONTH_STRINGS);
+    private static final String DAY_OF_MONTH_PATTERN = "(?=.* (\\d{1,2}) )";
+    private static final String MONTH_PATTERN = "(?=.* (" + COMBINED_MONTH_STRING + ") )";
+    private static final String YEAR_PATTERN = "(?=.* (\\d{4}) )";
+
+    /** Matches dd-MM-yyyy and dd/MM/yyyy formats. **/
+    private static final String STANDARD_DATE_PATTERN_STRING = "(\\d{2})[/-](\\d{2})[/-](\\d{4})";
+
+    /** Matches human-readable date formats like 10 Jan 2022 and 2011 Feb 20. **/
+    private static final String NATURAL_DATE_PATTERN_STRING =
+            String.format("^%s.*$", DAY_OF_MONTH_PATTERN + MONTH_PATTERN + YEAR_PATTERN);
+
+    /** Compiled pattern for dd-MM-yyyy and dd/MM/yyyy formats. **/
+    static final Pattern STANDARD_DATE_PATTERN = Pattern.compile(STANDARD_DATE_PATTERN_STRING);
+
+    /**
+     * Compiled pattern for human-readable date formats.
+     * See {@link #NATURAL_DATE_PATTERN_STRING} for pattern details.
+     **/
+    static final Pattern NATURAL_DATE_PATTERN = Pattern.compile(NATURAL_DATE_PATTERN_STRING,
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Translates the supplied {@code monthString} to its integer representation.
+     * Returns -1 if the supplied string is not in the {@code MONTH_STRINGS} array.
+     *
+     * @param monthString The month in String format to convert.
+     * @return The integer representation of the month if recognised, or -1 otherwise.
+     */
+    static int monthStringToDecimal(String monthString) {
+        int index = List.of(MONTH_STRINGS).indexOf(monthString);
+        if (index < 0) {
+            return -1;
+        }
+
+        // We note that the array repeats in meaning every 12 items.
+        // The +1 is to convert from a 0-based index to the 1-based index used by LocalDate.
+        return (index % 12) + 1;
+    }
+}

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/DateParserPatternProvider.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/DateParserPatternProvider.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * Provides commonly used constants for parsing dates. This class is package-private and is only visible to
+ * Provides regex patterns for parsing dates. This class is package-private and is only visible to
  * the {@code datetimeparser} package.
  */
 class DateParserPatternProvider {

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParser.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParser.java
@@ -1,0 +1,33 @@
+package seedu.contax.commons.util.datetimeparser;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+
+/**
+ * Provides parsing services for time inputs used in the application.
+ */
+public class TimeParser {
+    public static final String TIME_PATTERN = "HH:mm";
+
+    /**
+     * Parses a time input string to a {@code LocalTime} object.
+     *
+     * @param input The input time string to parse.
+     * @return An Optional container that contains a LocalTime object if parsing was successful, or an empty
+     *         Optional container if parsing was unsuccessful.
+     */
+    public static Optional<LocalTime> parseTime(String input) {
+        requireNonNull(input);
+
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(TIME_PATTERN);
+        try {
+            return Optional.of(LocalTime.parse(input, timeFormatter));
+        } catch (DateTimeParseException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParser.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParser.java
@@ -2,10 +2,10 @@ package seedu.contax.commons.util.datetimeparser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.DateTimeException;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Optional;
+import java.util.regex.Matcher;
 
 /**
  * Provides parsing services for time inputs used in the application.
@@ -23,10 +23,86 @@ public class TimeParser {
     public static Optional<LocalTime> parseTime(String input) {
         requireNonNull(input);
 
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(TIME_PATTERN);
+        return match12HourFormat(input).flatMap(TimeParser::parse12HourFormat)
+                .or(() -> match24HourFormat(input).flatMap(TimeParser::parse24HourFormat));
+    }
+
+    /**
+     * Returns a {@link Matcher} object if the input is in the 24-hour time format, contained in an
+     * {@code Optional}, and an empty {@code Optional} otherwise.
+     * See {@link TimeParserPatternProvider#TIME_24H_PATTERN} for more details on the expected format.
+     *
+     * @param input The input time string to match.
+     * @return A {@code Matcher} object in an Optional container if the supplied input matches, or an empty
+     *         optional otherwise.
+     */
+    private static Optional<Matcher> match24HourFormat(String input) {
+        Matcher match = TimeParserPatternProvider.TIME_24H_PATTERN.matcher(input);
+        if (!match.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(match);
+    }
+
+    /**
+     * Parses a 24-hour time format match into a {@link LocalTime} object.
+     *
+     * @param match The match object generated from matching an input string against
+     *              {@link TimeParserPatternProvider#TIME_24H_PATTERN}.
+     * @return A {@code LocalTime} object contained in an {@code Optional} if the input is valid, or an
+     *         empty {@code Optional} otherwise.
+     */
+    private static Optional<LocalTime> parse24HourFormat(Matcher match) {
         try {
-            return Optional.of(LocalTime.parse(input, timeFormatter));
-        } catch (DateTimeParseException ex) {
+            int hour = Integer.parseInt(match.group(1));
+            int minute = Integer.parseInt(match.group(2));
+
+            return Optional.of(LocalTime.of(hour, minute, 0));
+        } catch (NumberFormatException | DateTimeException ex) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns a {@link Matcher} object if the input is in the 12-hour time format, contained in an
+     * {@code Optional}, and an empty {@code Optional} otherwise.
+     * See {@link TimeParserPatternProvider#TIME_12H_PATTERN} for more details on the expected format.
+     *
+     * @param input The input time string to match.
+     * @return A {@code Matcher} object in an Optional container if the supplied input matches, or an empty
+     *         optional otherwise.
+     */
+    private static Optional<Matcher> match12HourFormat(String input) {
+        Matcher match = TimeParserPatternProvider.TIME_12H_PATTERN.matcher(input);
+        if (!match.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(match);
+    }
+
+    /**
+     * Parses a 12-hour time format match into a {@link LocalTime} object.
+     *
+     * @param match The match object generated from matching an input string against
+     *              {@link TimeParserPatternProvider#TIME_12H_PATTERN}.
+     * @return A {@code LocalTime} object contained in an {@code Optional} if the input is valid, or an
+     *         empty {@code Optional} otherwise.
+     */
+    private static Optional<LocalTime> parse12HourFormat(Matcher match) {
+        try {
+            int hour = Integer.parseInt(match.group(1));
+            int minute = Integer.parseInt(match.group(2));
+            boolean isPm = TimeParserPatternProvider.TIME_MODIFIER_PM.equalsIgnoreCase(match.group(3));
+
+            // 12am and 12pm require special handling due to 12am being 0 instead of 12
+            if (hour == 12) {
+                hour = isPm ? 12 : 0;
+            } else if (isPm) {
+                hour += 12;
+            }
+
+            return Optional.of(LocalTime.of(hour, minute, 0));
+        } catch (NumberFormatException | DateTimeException ex) {
             return Optional.empty();
         }
     }

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParser.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParser.java
@@ -11,7 +11,6 @@ import java.util.regex.Matcher;
  * Provides parsing services for time inputs used in the application.
  */
 public class TimeParser {
-    public static final String TIME_PATTERN = "HH:mm";
 
     /**
      * Parses a time input string to a {@code LocalTime} object.

--- a/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParserPatternProvider.java
+++ b/src/main/java/seedu/contax/commons/util/datetimeparser/TimeParserPatternProvider.java
@@ -1,0 +1,31 @@
+package seedu.contax.commons.util.datetimeparser;
+
+import java.util.regex.Pattern;
+
+/**
+ * Provides regex patterns used for parsing times. This class is package-private and is only visible to
+ * the {@code datetimeparser} package.
+ */
+class TimeParserPatternProvider {
+    static final String TIME_MODIFIER_AM = "am";
+    static final String TIME_MODIFIER_PM = "pm";
+
+    /** Matches the HH:mm or HH-mm 24-hour time format. **/
+    private static final String TIME_24H_PATTERN_STRING = "^([0-1]?[0-9]|2[0-3])[:-]([0-5]?[0-9])$";
+
+    /**
+     * Matches the HH:mm pm/am or HH-mm pm/am 12-hour time format.
+     * Note that 0 is not a valid value for the hour field, use 12 instead.
+     **/
+    private static final String TIME_12H_PATTERN_STRING = "^([0]?[1-9]|1[0-2])[:-]([0-5]?[0-9])[ ]?(pm|am)$";
+
+    /** Compiled pattern for HH:mm or HH-mm 24-hour time format. **/
+    static final Pattern TIME_24H_PATTERN = Pattern.compile(TIME_24H_PATTERN_STRING);
+
+    /**
+     * Compiled pattern for HH:mm pm/am or HH-mm pm/am 12-hour time format.
+     * Note that 0 is not a valid value for the hour field, use 12 instead.
+     **/
+    static final Pattern TIME_12H_PATTERN = Pattern.compile(TIME_12H_PATTERN_STRING,
+            Pattern.CASE_INSENSITIVE);
+}

--- a/src/test/java/seedu/contax/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/contax/commons/util/DateUtilTest.java
@@ -16,18 +16,20 @@ import org.junit.jupiter.api.Test;
 public class DateUtilTest {
     @Test
     public void parseDateTest() {
+        // Rigorous testing is done in DateParserTest.
         assertThrows(NullPointerException.class, () -> DateUtil.parseDate(null));
         assertEquals(Optional.empty(), DateUtil.parseDate("32-10-2022")); // Invalid Day
-        assertEquals(Optional.empty(), DateUtil.parseDate("0-10-2022")); // Invalid Day
-        assertEquals(Optional.empty(), DateUtil.parseDate("ab-10-2022")); // Invalid Day
         assertEquals(Optional.empty(), DateUtil.parseDate("20-13-2022")); // Invalid Month
         assertEquals(Optional.empty(), DateUtil.parseDate("20-0-2022")); // Invalid Month
-        assertEquals(Optional.empty(), DateUtil.parseDate("20-ab-2022")); // Invalid Month
-        assertEquals(Optional.empty(), DateUtil.parseDate("20-10-abcd")); // Invalid Year
-        assertEquals(Optional.empty(), DateUtil.parseDate("20-10-212")); // Invalid Year
+        assertEquals(Optional.empty(), DateUtil.parseDate("20-10-abc")); // Invalid Year
 
+        // Successful parsing
         assertEquals(LocalDate.parse("2022-10-20"), DateUtil.parseDate("20-10-2022").get());
-        assertEquals(LocalDate.parse("1971-03-30"), DateUtil.parseDate("30-03-1971").get());
+
+        // Different delimiters
+        assertEquals(LocalDate.parse("1971-03-30"), DateUtil.parseDate("30/03/1971").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateUtil.parseDate("30/03-1971").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateUtil.parseDate("30-03/1971").get());
     }
 
     @Test

--- a/src/test/java/seedu/contax/commons/util/datetimeparser/DateParserTest.java
+++ b/src/test/java/seedu/contax/commons/util/datetimeparser/DateParserTest.java
@@ -1,0 +1,81 @@
+package seedu.contax.commons.util.datetimeparser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class DateParserTest {
+    @Test
+    public void parseStandardDate() {
+        assertThrows(NullPointerException.class, () -> DateParser.parseDate(null));
+        assertEquals(Optional.empty(), DateParser.parseDate("32-10-2022")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("0-10-2022")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("ab-10-2022")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("20-13-2022")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20-0-2022")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20-ab-2022")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20-10-abcd")); // Invalid Year
+        assertEquals(Optional.empty(), DateParser.parseDate("20-10-212")); // Invalid Year
+
+        // Different delimiters
+        assertEquals(Optional.empty(), DateParser.parseDate("32/10/2022")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("ab/10/2022")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("20/13/2022")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20/ab/2022")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20/10/abcd")); // Invalid Year
+        assertEquals(Optional.empty(), DateParser.parseDate("20/10/212")); // Invalid Year
+
+        // Successful parsing
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("20-10-2022").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30-03-1971").get());
+
+        // Different delimiters
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30/03/1971").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30/03-1971").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30-03/1971").get());
+    }
+
+    @Test
+    public void parseNaturalDate() {
+        assertThrows(NullPointerException.class, () -> DateParser.parseDate(null));
+
+        // Missing Components
+        assertEquals(Optional.empty(), DateParser.parseDate("Jan 2022")); // Missing Day
+        assertEquals(Optional.empty(), DateParser.parseDate("10 2022")); // Missing Month
+        assertEquals(Optional.empty(), DateParser.parseDate("23 Jan")); // Missing Year
+
+        // Invalid Components
+        assertEquals(Optional.empty(), DateParser.parseDate("32 Jan 2022")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("0 March 2021")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("ab Dec 2020")); // Invalid Day
+        assertEquals(Optional.empty(), DateParser.parseDate("20 Dex 2020")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20 Mays 2021")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20 02 2022")); // Invalid Month
+        assertEquals(Optional.empty(), DateParser.parseDate("20 Mar abcd")); // Invalid Year
+        assertEquals(Optional.empty(), DateParser.parseDate("20 April 212")); // Invalid Year
+
+        // Successful parsing, standard forms
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("20 Oct 2022").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("20 October 2022").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30 March 1971").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30 Mar 1971").get());
+
+        // Successful parsing, different capitalization
+        assertEquals(LocalDate.parse("2022-11-20"), DateParser.parseDate("20 nov 2022").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("20 OCT 2022").get());
+        assertEquals(LocalDate.parse("1971-03-30"), DateParser.parseDate("30 MaRcH 1971").get());
+        assertEquals(LocalDate.parse("1971-04-30"), DateParser.parseDate("30 april 1971").get());
+
+        // Successful parsing, different ordering
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("20 Oct 2022").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("Oct 20 2022").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("Oct 2022 20").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("2022 Oct 20").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("2022 20 Oct").get());
+        assertEquals(LocalDate.parse("2022-10-20"), DateParser.parseDate("20 2022 Oct").get());
+    }
+}

--- a/src/test/java/seedu/contax/commons/util/datetimeparser/DateParserTest.java
+++ b/src/test/java/seedu/contax/commons/util/datetimeparser/DateParserTest.java
@@ -10,8 +10,20 @@ import org.junit.jupiter.api.Test;
 
 public class DateParserTest {
     @Test
-    public void parseStandardDate() {
+    public void parseDate_nullInput_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> DateParser.parseDate(null));
+    }
+
+    @Test
+    public void parseStandardDate() {
+        // Missing Components
+        assertEquals(Optional.empty(), DateParser.parseDate("-10-2022"));
+        assertEquals(Optional.empty(), DateParser.parseDate("10--2022"));
+        assertEquals(Optional.empty(), DateParser.parseDate("10-10-"));
+        assertEquals(Optional.empty(), DateParser.parseDate("10-10"));
+        assertEquals(Optional.empty(), DateParser.parseDate("10-2022"));
+
+        // Invalid Components
         assertEquals(Optional.empty(), DateParser.parseDate("32-10-2022")); // Invalid Day
         assertEquals(Optional.empty(), DateParser.parseDate("0-10-2022")); // Invalid Day
         assertEquals(Optional.empty(), DateParser.parseDate("ab-10-2022")); // Invalid Day
@@ -41,8 +53,6 @@ public class DateParserTest {
 
     @Test
     public void parseNaturalDate() {
-        assertThrows(NullPointerException.class, () -> DateParser.parseDate(null));
-
         // Missing Components
         assertEquals(Optional.empty(), DateParser.parseDate("Jan 2022")); // Missing Day
         assertEquals(Optional.empty(), DateParser.parseDate("10 2022")); // Missing Month

--- a/src/test/java/seedu/contax/commons/util/datetimeparser/TimeParserTest.java
+++ b/src/test/java/seedu/contax/commons/util/datetimeparser/TimeParserTest.java
@@ -1,0 +1,93 @@
+package seedu.contax.commons.util.datetimeparser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class TimeParserTest {
+    @Test
+    public void parseTime_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> TimeParser.parseTime(null));
+    }
+
+    @Test
+    public void parse24HourTime() {
+        // Missing Components
+        assertEquals(Optional.empty(), TimeParser.parseTime(":20"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10:"));
+        assertEquals(Optional.empty(), TimeParser.parseTime(":"));
+
+        // Invalid Components
+        assertEquals(Optional.empty(), TimeParser.parseTime("aa:20"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("25:20"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("-1:20"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("20:aa"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("20:60"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("20:-1"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("aa:aa"));
+
+        // Different delimiters
+        assertEquals(Optional.empty(), TimeParser.parseTime("aa-20"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("20-aa"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("aa-aa"));
+
+        // Successful parsing
+        assertEquals(LocalTime.of(0, 0), TimeParser.parseTime("00:00").get());
+        assertEquals(LocalTime.of(23, 59), TimeParser.parseTime("23:59").get());
+        assertEquals(LocalTime.of(12, 30), TimeParser.parseTime("12:30").get());
+        assertEquals(LocalTime.of(11, 59), TimeParser.parseTime("11:59").get());
+        assertEquals(LocalTime.of(12, 2), TimeParser.parseTime("12:02").get());
+
+        // Different delimiters
+        assertEquals(LocalTime.of(12, 30), TimeParser.parseTime("12-30").get());
+        assertEquals(LocalTime.of(11, 59), TimeParser.parseTime("11-59").get());
+        assertEquals(LocalTime.of(12, 2), TimeParser.parseTime("12-02").get());
+    }
+
+    @Test
+    public void parse12HourTime() {
+        // Missing Components
+        assertEquals(Optional.empty(), TimeParser.parseTime(":20 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10: pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime(": pm"));
+
+        // Invalid Components
+        assertEquals(Optional.empty(), TimeParser.parseTime("aa:20 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("13:20 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("13:20 am"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("00:05 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("00:05 am"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10:aa pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10:60 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10:-1 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10:10 fm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("aa:aa pm"));
+
+        // Different delimiters
+        assertEquals(Optional.empty(), TimeParser.parseTime("13-20 pm"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("13-20 am"));
+        assertEquals(Optional.empty(), TimeParser.parseTime("10-10 fm"));
+
+        // Fallback to 24 hour without pm/am modifier
+        assertEquals(LocalTime.of(10, 0), TimeParser.parseTime("10:00").get());
+
+        // Successful parsing
+        assertEquals(LocalTime.of(0, 2), TimeParser.parseTime("12:02 am").get());
+        assertEquals(LocalTime.of(12, 3), TimeParser.parseTime("12:03 pm").get());
+        assertEquals(LocalTime.of(0, 59), TimeParser.parseTime("12:59 AM").get());
+        assertEquals(LocalTime.of(12, 59), TimeParser.parseTime("12:59 PM").get());
+        assertEquals(LocalTime.of(11, 59), TimeParser.parseTime("11:59 am").get());
+        assertEquals(LocalTime.of(23, 59), TimeParser.parseTime("11:59 pm").get());
+        assertEquals(LocalTime.of(0, 0), TimeParser.parseTime("12:00 am").get());
+        assertEquals(LocalTime.of(12, 0), TimeParser.parseTime("12:00 pm").get());
+
+        // Different delimiters
+        assertEquals(LocalTime.of(12, 30), TimeParser.parseTime("12-30 pm").get());
+        assertEquals(LocalTime.of(11, 59), TimeParser.parseTime("11-59 am").get());
+        assertEquals(LocalTime.of(0, 2), TimeParser.parseTime("12-02 am").get());
+    }
+}

--- a/src/test/java/seedu/contax/testutil/DateInputUtil.java
+++ b/src/test/java/seedu/contax/testutil/DateInputUtil.java
@@ -10,7 +10,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
-import seedu.contax.commons.util.DateUtil;
+import seedu.contax.commons.util.datetimeparser.DateParser;
+import seedu.contax.commons.util.datetimeparser.TimeParser;
 
 /**
  * Provides conversion service from java datetime objects to String inputs for parsing tests.
@@ -23,7 +24,7 @@ public class DateInputUtil {
      * @return A string representing {@code date} that can be accepted as a command input.
      */
     public static String formatDateToInputString(LocalDate date) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateUtil.DATE_PATTERN);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateParser.DATE_PATTERN);
         return date.format(formatter);
     }
 
@@ -34,7 +35,7 @@ public class DateInputUtil {
      * @return A string representing {@code time} that can be accepted as a command input.
      */
     public static String formatTimeToInputString(LocalTime time) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateUtil.TIME_PATTERN);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(TimeParser.TIME_PATTERN);
         return time.format(formatter);
     }
 

--- a/src/test/java/seedu/contax/testutil/DateInputUtil.java
+++ b/src/test/java/seedu/contax/testutil/DateInputUtil.java
@@ -10,13 +10,13 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
-import seedu.contax.commons.util.datetimeparser.DateParser;
-import seedu.contax.commons.util.datetimeparser.TimeParser;
-
 /**
  * Provides conversion service from java datetime objects to String inputs for parsing tests.
  */
 public class DateInputUtil {
+    public static final String TIME_INPUT_PATTERN = "HH:mm";
+    public static final String DATE_INPUT_PATTERN = "dd-MM-yyyy";
+
     /**
      * Returns {@code date} in a string that can be accepted as command inputs.
      *
@@ -24,7 +24,7 @@ public class DateInputUtil {
      * @return A string representing {@code date} that can be accepted as a command input.
      */
     public static String formatDateToInputString(LocalDate date) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateParser.DATE_PATTERN);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_INPUT_PATTERN);
         return date.format(formatter);
     }
 
@@ -35,7 +35,7 @@ public class DateInputUtil {
      * @return A string representing {@code time} that can be accepted as a command input.
      */
     public static String formatTimeToInputString(LocalTime time) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(TimeParser.TIME_PATTERN);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(TIME_INPUT_PATTERN);
         return time.format(formatter);
     }
 


### PR DESCRIPTION
## Changes
This PR adds the support for accepting natural date and time input formats. In particular, the new input parser allows:

- Using / as a delimiter for dates: `30/12/2022`
- Textual Months: `20 Dec 2023`, `20 november 2020`
- 12-hour Time: `11:30 PM`

See the updated UG for more details.

## Related Issues
- Closes #197