### PR TITLE
Enable Assertions for Run Task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '8.29'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport


### PR DESCRIPTION
## Changes
This PR enables assertions in the gradle build file, per the requirements in the weekly tasks.

## Related Issues
- None, this is a chore.