### PR TITLE
Version Bump - 1.2.1

### DIFF
--- a/src/main/java/seedu/contax/MainApp.java
+++ b/src/main/java/seedu/contax/MainApp.java
@@ -40,7 +40,7 @@ import seedu.contax.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 0, true);
+    public static final Version VERSION = new Version(1, 2, 1, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 


### PR DESCRIPTION
This PR bumps the internal version number to v1.2.1 for the trial release required for Week 10 milestones. 