### PR TITLE
Bug fix for range support reordering

### DIFF
--- a/src/main/java/seedu/contax/logic/commands/RangeCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/RangeCommand.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.commons.core.Messages;
 import seedu.contax.commons.core.index.Index;
-import seedu.contax.logic.LogicManager;
 import seedu.contax.logic.commands.exceptions.CommandException;
 import seedu.contax.logic.parser.AddressBookParser;
 import seedu.contax.logic.parser.ParserUtil;

--- a/src/main/java/seedu/contax/logic/commands/RangeCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/RangeCommand.java
@@ -9,9 +9,12 @@ import static seedu.contax.logic.parser.CliSyntax.PREFIX_RANGE_TO;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
+import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.commons.core.Messages;
 import seedu.contax.commons.core.index.Index;
+import seedu.contax.logic.LogicManager;
 import seedu.contax.logic.commands.exceptions.CommandException;
 import seedu.contax.logic.parser.AddressBookParser;
 import seedu.contax.logic.parser.ParserUtil;
@@ -33,6 +36,8 @@ public class RangeCommand extends Command {
             + "Example: " + COMMAND_WORD + " edit "
             + PREFIX_PHONE + "12345678 "
             + PREFIX_ADDRESS + "new address ";
+
+    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
     private final Index fromIndex;
     private final Index toIndex;
@@ -61,6 +66,9 @@ public class RangeCommand extends Command {
             AddressBookParser addressBookParser = new AddressBookParser();
             try {
                 String commandText = ParserUtil.parseAndCreateNewCommand(commandInput, Integer.toString(i));
+
+                logger.info("----------------[RANGE COMMAND][" + commandText + "]");
+
                 Command command = addressBookParser.parseCommand(commandText);
                 commandResultList.add(command.execute(model));
             } catch (ParseException pe) {

--- a/src/main/java/seedu/contax/logic/commands/RangeCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/RangeCommand.java
@@ -37,7 +37,7 @@ public class RangeCommand extends Command {
             + PREFIX_PHONE + "12345678 "
             + PREFIX_ADDRESS + "new address ";
 
-    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
+    private final Logger logger = LogsCenter.getLogger(RangeCommand.class);
 
     private final Index fromIndex;
     private final Index toIndex;

--- a/src/main/java/seedu/contax/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/contax/logic/parser/ParserUtil.java
@@ -251,7 +251,7 @@ public class ParserUtil {
         StringBuilder output = new StringBuilder();
         commandInput = commandInput.trim();
         String[] splitCommand = commandInput.split(" ");
-        output.append(splitCommand[0]).append(" ").append(index).append(" ");
+        output.append(splitCommand[0]).append(" ").append(index);
         if (commandInput.contains(" ")) {
             output.append(commandInput.substring(splitCommand[0].length()));
         }

--- a/src/main/java/seedu/contax/logic/parser/RangeCommandParser.java
+++ b/src/main/java/seedu/contax/logic/parser/RangeCommandParser.java
@@ -25,7 +25,7 @@ public class RangeCommandParser implements Parser<RangeCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_RANGE_FROM, PREFIX_RANGE_TO);
 
-        String commandInput = args.split("from/")[0];
+        String commandInput = argMultimap.getPreamble();
 
         Index fromIndex;
         Index toIndex;

--- a/src/test/java/seedu/contax/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/contax/logic/parser/ParserUtilTest.java
@@ -356,7 +356,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseAndCreateNewCommand_returnsCommand() throws ParseException {
-        assertEquals("test 1  command",
+        assertEquals("test 1 command",
                 ParserUtil.parseAndCreateNewCommand("test command", "1"));
     }
     @Test


### PR DESCRIPTION
This PR correct the range command that support reorder `from/` `to/`