### PR TITLE
Fix Free Slot Display Update

### DIFF
--- a/src/main/java/seedu/contax/logic/commands/FreeBetweenCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/FreeBetweenCommand.java
@@ -10,12 +10,9 @@ import static seedu.contax.logic.parser.CliSyntax.PREFIX_TIME_START;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.contax.commons.core.GuiListContentType;
 import seedu.contax.model.Model;
-import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.appointment.DateRangePredicate;
 import seedu.contax.model.chrono.TimeRange;
 
@@ -71,12 +68,7 @@ public class FreeBetweenCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredAppointmentList(new DateRangePredicate(rangeStart, rangeEnd));
-        List<TimeRange> slotsFound = model.getSchedule()
-                .findSlotsBetweenAppointments(rangeStart, rangeEnd, duration);
-        List<AppointmentSlot> slotList = slotsFound.stream()
-                .map(AppointmentSlot::new)
-                .collect(Collectors.toList());
-        model.setDisplayedAppointmentSlots(slotList);
+        model.setDisplayedAppointmentSlotRange(new TimeRange(rangeStart, rangeEnd), duration);
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATETIME_DISPLAY_FORMAT);
         String responseMessage = String.format(MESSAGE_SUCCESS, duration, rangeStart.format(formatter),

--- a/src/main/java/seedu/contax/model/AppointmentSlotList.java
+++ b/src/main/java/seedu/contax/model/AppointmentSlotList.java
@@ -1,5 +1,6 @@
 package seedu.contax.model;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.contax.commons.util.AppUtil.checkArgument;
 
 import java.util.List;
@@ -30,6 +31,8 @@ public class AppointmentSlotList {
      * @param backingSchedule The backing Schedule that slots should be generated for.
      */
     public AppointmentSlotList(Schedule backingSchedule) {
+        requireNonNull(backingSchedule);
+
         this.backingSchedule = backingSchedule;
         this.filteredRange = null;
         this.resultList = FXCollections.observableArrayList();
@@ -83,13 +86,14 @@ public class AppointmentSlotList {
 
         // state check
         AppointmentSlotList other = (AppointmentSlotList) obj;
-        return Objects.equals(filteredRange, other.filteredRange)
+        return backingSchedule.equals(other.backingSchedule)
+                && Objects.equals(filteredRange, other.filteredRange)
                 && minimumDuration == other.minimumDuration;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(minimumDuration, filteredRange);
+        return Objects.hash(backingSchedule, minimumDuration, filteredRange);
     }
 
     /**

--- a/src/main/java/seedu/contax/model/AppointmentSlotList.java
+++ b/src/main/java/seedu/contax/model/AppointmentSlotList.java
@@ -1,0 +1,119 @@
+package seedu.contax.model;
+
+import static seedu.contax.commons.util.AppUtil.checkArgument;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javafx.beans.InvalidationListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.contax.model.appointment.AppointmentSlot;
+import seedu.contax.model.chrono.TimeRange;
+
+/**
+ * Generates a list of slots from the backing Schedule between the specified time range.
+ */
+public class AppointmentSlotList {
+
+    private TimeRange filteredRange;
+    private int minimumDuration;
+    private final Schedule backingSchedule;
+    private final ObservableList<AppointmentSlot> resultList;
+    private final ObservableList<AppointmentSlot> readOnlyResultList;
+    private final InvalidationListener sourceChangeListener;
+
+    /**
+     * Constructs an {@code AppointmentSlotList}.
+     *
+     * @param backingSchedule The backing Schedule that slots should be generated for.
+     */
+    public AppointmentSlotList(Schedule backingSchedule) {
+        this.backingSchedule = backingSchedule;
+        this.filteredRange = null;
+        this.resultList = FXCollections.observableArrayList();
+        this.readOnlyResultList = FXCollections.unmodifiableObservableList(this.resultList);
+        this.sourceChangeListener = (unused) -> {
+            updateResultList();
+        };
+    }
+
+    /**
+     * Updates the time range within which slots should be generated for.
+     *
+     * @param newRange The new {@code TimeRange} for which slots should be generated for. This is a nullable
+     *                 field, where the result list is cleared if null is supplied.
+     * @param minimumDuration The minimum duration for an AppointmentSlot to be considered valid.
+     */
+    public void updateFilteredRange(TimeRange newRange, int minimumDuration) {
+        this.filteredRange = newRange;
+        if (newRange == null) {
+            this.resultList.clear();
+            detachListener();
+            return;
+        }
+
+        checkArgument(minimumDuration > 0, "The minimum duration should be positive");
+        this.minimumDuration = minimumDuration;
+
+        updateResultList();
+        attachListener();
+    }
+
+    /**
+     * Returns the generated list of AppointmentSlot objects in the specified time range, or an empty list
+     * if no time range is specified.
+     */
+    public ObservableList<AppointmentSlot> getSlotList() {
+        return this.readOnlyResultList;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof AppointmentSlotList)) {
+            return false;
+        }
+
+        // state check
+        AppointmentSlotList other = (AppointmentSlotList) obj;
+        return Objects.equals(filteredRange, other.filteredRange)
+                && minimumDuration == other.minimumDuration;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimumDuration, filteredRange);
+    }
+
+    /**
+     * Attaches an update listener to the backing schedule.
+     */
+    private void attachListener() {
+        backingSchedule.getAppointmentList().addListener(sourceChangeListener);
+    }
+
+    /**
+     * Detaches the update listener from the backing schedule.
+     */
+    private void detachListener() {
+        backingSchedule.getAppointmentList().removeListener(sourceChangeListener);
+    }
+
+    /**
+     * Updates the result list with the generated list of slots.
+     */
+    private void updateResultList() {
+        List<TimeRange> slotsFound = backingSchedule.findSlotsBetweenAppointments(
+                filteredRange.getStartDateTime(), filteredRange.getEndDateTime(), minimumDuration);
+        this.resultList.setAll(slotsFound.stream()
+                .map(AppointmentSlot::new)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/seedu/contax/model/Model.java
+++ b/src/main/java/seedu/contax/model/Model.java
@@ -1,7 +1,6 @@
 package seedu.contax.model;
 
 import java.nio.file.Path;
-import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -9,6 +8,7 @@ import seedu.contax.commons.core.GuiSettings;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.chrono.ScheduleItem;
+import seedu.contax.model.chrono.TimeRange;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
 
@@ -194,9 +194,10 @@ public interface Model {
     /**
      * Sets the list of slots between appointments to highlight.
      *
-     * @param items A list containing the ranges between appointments to highlight.
+     * @param range The time range between which slots in the schedule should be displayed.
+     * @param minimumDuration The minimum duration of a slot for it to be displayed.
      */
-    void setDisplayedAppointmentSlots(List<AppointmentSlot> items);
+    void setDisplayedAppointmentSlotRange(TimeRange range, int minimumDuration);
 
     /**
      * Clears all the highlighted empty slots in the Schedule.

--- a/src/main/java/seedu/contax/model/ModelManager.java
+++ b/src/main/java/seedu/contax/model/ModelManager.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.contax.commons.core.GuiSettings;
@@ -17,6 +16,7 @@ import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.chrono.ScheduleItem;
+import seedu.contax.model.chrono.TimeRange;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
 
@@ -33,8 +33,7 @@ public class ModelManager implements Model {
     private final FilteredList<Appointment> filteredAppointments;
     private final FilteredList<Tag> filteredTags;
 
-    private final ObservableList<AppointmentSlot> displayedAppointmentSlots;
-    private final ObservableList<AppointmentSlot> unmodifiableDisplayedAppointmentSlots;
+    private final AppointmentSlotList displayedAppointmentSlots;
     private final CompositeTemporalObservableList<ScheduleItem> scheduleItemList;
 
     /**
@@ -54,11 +53,9 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredAppointments = new FilteredList<>(this.schedule.getAppointmentList());
         filteredTags = new FilteredList<>(this.addressBook.getTagList());
-        displayedAppointmentSlots = FXCollections.observableArrayList();
-        unmodifiableDisplayedAppointmentSlots =
-                FXCollections.unmodifiableObservableList(displayedAppointmentSlots);
+        displayedAppointmentSlots = new AppointmentSlotList(this.schedule);
         scheduleItemList = new CompositeTemporalObservableList<>(filteredAppointments,
-                unmodifiableDisplayedAppointmentSlots);
+                displayedAppointmentSlots.getSlotList());
     }
 
     /**
@@ -292,18 +289,18 @@ public class ModelManager implements Model {
 
     @Override
     public ObservableList<AppointmentSlot> getDisplayedAppointmentSlots() {
-        return unmodifiableDisplayedAppointmentSlots;
+        return displayedAppointmentSlots.getSlotList();
     }
 
     @Override
-    public void setDisplayedAppointmentSlots(List<AppointmentSlot> items) {
-        requireNonNull(items);
-        displayedAppointmentSlots.setAll(items);
+    public void setDisplayedAppointmentSlotRange(TimeRange range, int minimumDuration) {
+        requireNonNull(range);
+        displayedAppointmentSlots.updateFilteredRange(range, minimumDuration);
     }
 
     @Override
     public void clearDisplayedAppointmentSlots() {
-        displayedAppointmentSlots.clear();
+        displayedAppointmentSlots.updateFilteredRange(null, 0);
     }
 
     @Override

--- a/src/test/java/seedu/contax/logic/commands/AddAppointmentCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddAppointmentCommandTest.java
@@ -31,6 +31,7 @@ import seedu.contax.model.Schedule;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.chrono.ScheduleItem;
+import seedu.contax.model.chrono.TimeRange;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
 import seedu.contax.testutil.AppointmentBuilder;
@@ -287,7 +288,7 @@ public class AddAppointmentCommandTest {
         }
 
         @Override
-        public void setDisplayedAppointmentSlots(List<AppointmentSlot> items) {
+        public void setDisplayedAppointmentSlotRange(TimeRange range, int minimumDuration) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddPersonCommandTest.java
@@ -25,6 +25,7 @@ import seedu.contax.model.ReadOnlyUserPrefs;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.chrono.ScheduleItem;
+import seedu.contax.model.chrono.TimeRange;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
 import seedu.contax.testutil.PersonBuilder;
@@ -246,7 +247,7 @@ public class AddPersonCommandTest {
         }
 
         @Override
-        public void setDisplayedAppointmentSlots(List<AppointmentSlot> items) {
+        public void setDisplayedAppointmentSlotRange(TimeRange range, int minimumDuration) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddPersonCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.contax.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
@@ -26,6 +26,7 @@ import seedu.contax.model.ReadOnlyUserPrefs;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.chrono.ScheduleItem;
+import seedu.contax.model.chrono.TimeRange;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
 import seedu.contax.testutil.TagBuilder;
@@ -199,7 +200,7 @@ class AddTagCommandTest {
         }
 
         @Override
-        public void setDisplayedAppointmentSlots(List<AppointmentSlot> items) {
+        public void setDisplayedAppointmentSlotRange(TimeRange range, int minimumDuration) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/AddTagCommandTest.java
@@ -11,7 +11,6 @@ import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/contax/logic/commands/RangeCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/RangeCommandTest.java
@@ -31,6 +31,7 @@ import seedu.contax.model.UserPrefs;
 import seedu.contax.model.appointment.Appointment;
 import seedu.contax.model.appointment.AppointmentSlot;
 import seedu.contax.model.chrono.ScheduleItem;
+import seedu.contax.model.chrono.TimeRange;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.tag.Tag;
 
@@ -275,7 +276,7 @@ public class RangeCommandTest {
         }
 
         @Override
-        public void setDisplayedAppointmentSlots(List<AppointmentSlot> items) {
+        public void setDisplayedAppointmentSlotRange(TimeRange range, int minimumDuration) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/contax/logic/commands/RangeCommandTest.java
+++ b/src/test/java/seedu/contax/logic/commands/RangeCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/contax/model/AppointmentSlotListTest.java
+++ b/src/test/java/seedu/contax/model/AppointmentSlotListTest.java
@@ -1,0 +1,148 @@
+package seedu.contax.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.contax.testutil.Assert.assertThrows;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.contax.model.appointment.AppointmentSlot;
+import seedu.contax.model.chrono.TimeRange;
+import seedu.contax.testutil.AppointmentBuilder;
+import seedu.contax.testutil.ScheduleBuilder;
+
+public class AppointmentSlotListTest {
+
+    private Schedule schedule;
+
+    @BeforeEach
+    public void initializeSchedule() {
+        schedule = new ScheduleBuilder()
+                .withAppointment(new AppointmentBuilder()
+                        .withName("Test 1")
+                        .withStartDateTime(LocalDateTime.of(2022, 5, 29, 12, 0))
+                        .withDuration(30)
+                        .build()
+                ).withAppointment(new AppointmentBuilder()
+                        .withName("Test 2")
+                        .withStartDateTime(LocalDateTime.of(2022, 5, 29, 13, 0))
+                        .withDuration(60)
+                        .build()
+                ).withAppointment(new AppointmentBuilder()
+                        .withName("Test 3")
+                        .withStartDateTime(LocalDateTime.of(2022, 5, 29, 15, 0))
+                        .withDuration(30)
+                        .build()
+                ).build();
+    }
+
+    @Test
+    public void constructor_nullSchedule_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AppointmentSlotList(null));
+    }
+
+    @Test
+    public void constructor_emptyRange_nothingListed() {
+        AppointmentSlotList slotList = new AppointmentSlotList(schedule);
+        assertEquals(List.of(), slotList.getSlotList());
+    }
+
+    @Test
+    public void constructor_validRange_slotsListed() {
+        // Thorough testing is done in DisjointAppointmentListTest
+        AppointmentSlotList slotList = new AppointmentSlotList(schedule);
+        assertEquals(List.of(), slotList.getSlotList());
+
+        slotList.updateFilteredRange(new TimeRange(
+                LocalDateTime.of(2022, 5, 29, 12, 0),
+                LocalDateTime.of(2022, 5, 29, 16, 0)), 60);
+        assertEquals(List.of(
+                new AppointmentSlot(new TimeRange(
+                        LocalDateTime.of(2022, 5, 29, 14, 0),
+                        LocalDateTime.of(2022, 5, 29, 15, 0)
+                ))
+        ), slotList.getSlotList());
+
+        // Test delete update listener
+        schedule.removeAppointment(schedule.getAppointmentList().get(2));
+        assertEquals(List.of(
+                new AppointmentSlot(new TimeRange(
+                        LocalDateTime.of(2022, 5, 29, 14, 0),
+                        LocalDateTime.of(2022, 5, 29, 16, 0)
+                ))
+        ), slotList.getSlotList());
+
+        // Test add update listener
+        schedule.addAppointment(new AppointmentBuilder()
+                .withName("Test 4")
+                .withStartDateTime(LocalDateTime.of(2022, 5, 29, 15, 30))
+                .withDuration(15).build());
+        assertEquals(List.of(
+                new AppointmentSlot(new TimeRange(
+                        LocalDateTime.of(2022, 5, 29, 14, 0),
+                        LocalDateTime.of(2022, 5, 29, 15, 30)
+                ))
+        ), slotList.getSlotList());
+
+        // Test clearing
+        slotList.updateFilteredRange(null, 0);
+        assertEquals(List.of(), slotList.getSlotList());
+    }
+
+    @Test
+    public void equals() {
+        AppointmentSlotList slotList = new AppointmentSlotList(schedule);
+        AppointmentSlotList slotList2 = new AppointmentSlotList(schedule);
+
+        // same values -> returns true
+        assertTrue(slotList.equals(slotList2));
+
+        // same object -> returns true
+        assertTrue(slotList.equals(slotList));
+
+        // null -> returns false
+        assertFalse(slotList.equals(null));
+
+        // different schedule -> returns false
+        assertFalse(slotList.equals(new AppointmentSlotList(new Schedule())));
+
+        // different time range -> returns false
+        slotList.updateFilteredRange(new TimeRange(LocalDateTime.MIN,
+                LocalDateTime.of(2020, 1, 1, 1, 1)), 1);
+        slotList2.updateFilteredRange(new TimeRange(LocalDateTime.MIN,
+                LocalDateTime.of(2021, 1, 1, 1, 1)), 1);
+        assertFalse(slotList.equals(slotList2));
+
+        // different duration -> returns false
+        slotList.updateFilteredRange(new TimeRange(LocalDateTime.MIN,
+                LocalDateTime.of(2020, 1, 1, 1, 1)), 1);
+        slotList2.updateFilteredRange(new TimeRange(LocalDateTime.MIN,
+                LocalDateTime.of(2020, 1, 1, 1, 1)), 2);
+        assertFalse(slotList.equals(slotList2));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        AppointmentSlotList slotList = new AppointmentSlotList(schedule);
+        AppointmentSlotList slotList2 = new AppointmentSlotList(schedule);
+
+        assertEquals(slotList.hashCode(), slotList2.hashCode());
+        assertNotEquals(slotList.hashCode(), new AppointmentSlotList(new Schedule()).hashCode());
+
+        // Different time range
+        slotList.updateFilteredRange(new TimeRange(LocalDateTime.MIN, LocalDateTime.MIN), 1);
+        slotList2.updateFilteredRange(new TimeRange(LocalDateTime.MIN, LocalDateTime.MAX), 1);
+        assertNotEquals(slotList.hashCode(), slotList2.hashCode());
+
+        // Different duration
+        slotList.updateFilteredRange(new TimeRange(LocalDateTime.MIN, LocalDateTime.MAX), 1);
+        slotList2.updateFilteredRange(new TimeRange(LocalDateTime.MIN, LocalDateTime.MAX), 2);
+        assertNotEquals(slotList.hashCode(), slotList2.hashCode());
+    }
+}

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -384,21 +384,36 @@ public class ModelManagerTest {
 
     @Test
     public void setDisplayedAppointmentSlots_nullInput_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setDisplayedAppointmentSlots(null));
+        assertThrows(NullPointerException.class, () -> modelManager.setDisplayedAppointmentSlotRange(null, 1));
     }
 
     @Test
-    public void setDisplayedAppointmentSlots_validList_success() {
+    public void setDisplayedAppointmentSlots_validTimeRange_success() {
         List<AppointmentSlot> sampleSlots = List.of(
-                new AppointmentSlot(new TimeRange(LocalDate.of(2022, 1, 1).atStartOfDay(),
-                        LocalDate.of(2022, 1, 1).atTime(23, 59))),
-                new AppointmentSlot(new TimeRange(LocalDate.of(2022, 1, 2).atStartOfDay(),
-                        LocalDate.of(2022, 1, 2).atTime(23, 59))),
-                new AppointmentSlot(new TimeRange(LocalDate.of(2022, 2, 3).atStartOfDay(),
-                        LocalDate.of(2022, 2, 3).atTime(23, 59)))
+                new AppointmentSlot(new TimeRange(
+                        LocalDate.of(2022, 5, 3).atTime(10, 59),
+                        LocalDate.of(2022, 5, 3).atTime(12, 0))
+                ),
+                new AppointmentSlot(new TimeRange(
+                        LocalDate.of(2022, 5, 3).atTime(12, 30),
+                        LocalDate.of(2022, 5, 3).atTime(14, 0))
+                )
         );
+        modelManager.addAppointment(new AppointmentBuilder().withName("Test 1")
+                .withStartDateTime(LocalDateTime.of(2022, 5, 3, 12, 0))
+                .withDuration(30).build()
+        );
+        modelManager.addAppointment(new AppointmentBuilder().withName("Test 2")
+                .withStartDateTime(LocalDateTime.of(2022, 5, 3, 14, 0))
+                .withDuration(60).build()
+        );
+
         assertEquals(List.of(), modelManager.getDisplayedAppointmentSlots());
-        modelManager.setDisplayedAppointmentSlots(sampleSlots);
+        modelManager.setDisplayedAppointmentSlotRange(
+                new TimeRange(
+                        LocalDate.of(2022, 5, 3).atTime(10, 59),
+                        LocalDate.of(2022, 5, 3).atTime(15, 0)
+                ),61);
         assertEquals(sampleSlots, modelManager.getDisplayedAppointmentSlots());
         modelManager.clearDisplayedAppointmentSlots();
         assertEquals(List.of(), modelManager.getDisplayedAppointmentSlots());
@@ -455,7 +470,8 @@ public class ModelManagerTest {
                 new AppointmentSlot(new TimeRange(LocalDateTime.MIN, LocalDateTime.MAX))
         );
         ModelManager differentModelManager = new ModelManager();
-        differentModelManager.setDisplayedAppointmentSlots(differentAppointmentSlots);
+        differentModelManager.setDisplayedAppointmentSlotRange(new TimeRange(LocalDateTime.MIN,
+                LocalDateTime.MAX), 1);
         assertFalse(modelManager.equals(differentModelManager));
     }
 }

--- a/src/test/java/seedu/contax/model/ModelManagerTest.java
+++ b/src/test/java/seedu/contax/model/ModelManagerTest.java
@@ -413,7 +413,7 @@ public class ModelManagerTest {
                 new TimeRange(
                         LocalDate.of(2022, 5, 3).atTime(10, 59),
                         LocalDate.of(2022, 5, 3).atTime(15, 0)
-                ),61);
+                ), 61);
         assertEquals(sampleSlots, modelManager.getDisplayedAppointmentSlots());
         modelManager.clearDisplayedAppointmentSlots();
         assertEquals(List.of(), modelManager.getDisplayedAppointmentSlots());

--- a/src/test/java/seedu/contax/model/appointment/AppointmentSlotTest.java
+++ b/src/test/java/seedu/contax/model/appointment/AppointmentSlotTest.java
@@ -1,7 +1,9 @@
 package seedu.contax.model.appointment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 
@@ -24,5 +26,16 @@ public class AppointmentSlotTest {
 
         assertEquals("Start Date Time: " + startTime + "; End Date Time: " + endTime,
                 appointmentSlot.toString());
+    }
+
+    @Test
+    public void equals() {
+        LocalDateTime startTime = LocalDateTime.MIN;
+        LocalDateTime endTime = LocalDateTime.MAX;
+        AppointmentSlot appointmentSlot = new AppointmentSlot(new TimeRange(startTime, endTime));
+
+        assertTrue(appointmentSlot.equals(appointmentSlot));
+        assertTrue(appointmentSlot.equals(new AppointmentSlot(new TimeRange(startTime, endTime))));
+        assertFalse(appointmentSlot.equals(new AppointmentSlot(new TimeRange(startTime, startTime))));
     }
 }


### PR DESCRIPTION
## Changes
This PR is a bugfix that directly addresses the issue #239. It changes how the flow of displaying empty slots in the schedule is handled, and solves the problem of slots not combining.

## Related Issues
- Closes #239 