### PR TITLE
Improvement - Adjust json parsing to be forgiving

### DIFF
--- a/src/main/java/seedu/contax/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/contax/storage/JsonAdaptedPerson.java
@@ -59,6 +59,10 @@ class JsonAdaptedPerson {
                 .collect(Collectors.toList()));
     }
 
+    public String getPersonNameString() {
+        return name;
+    }
+
     /**
      * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
      *

--- a/src/main/java/seedu/contax/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/contax/storage/JsonAddressBookStorage.java
@@ -9,7 +9,6 @@ import java.util.logging.Logger;
 
 import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.commons.exceptions.DataConversionException;
-import seedu.contax.commons.exceptions.IllegalValueException;
 import seedu.contax.commons.util.FileUtil;
 import seedu.contax.commons.util.JsonUtil;
 import seedu.contax.model.ReadOnlyAddressBook;
@@ -51,12 +50,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
             return Optional.empty();
         }
 
-        try {
-            return Optional.of(jsonAddressBook.get().toModelType());
-        } catch (IllegalValueException ive) {
-            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
-            throw new DataConversionException(ive);
-        }
+        return Optional.of(jsonAddressBook.get().toModelType());
     }
 
     @Override

--- a/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
@@ -61,9 +61,15 @@ class JsonSerializableAddressBook {
         }
 
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
-            Person person = jsonAdaptedPerson.toModelType();
-            if (addressBook.hasPerson(person)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+            Person person;
+            try {
+                person = jsonAdaptedPerson.toModelType();
+                if (addressBook.hasPerson(person)) {
+                    //skip instead of throwing exception
+                    throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+                }
+            } catch (IllegalValueException e) {
+                continue;
             }
 
             // Load tags that were not added from tag list

--- a/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
@@ -49,13 +49,18 @@ class JsonSerializableAddressBook {
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
-    public AddressBook toModelType() throws IllegalValueException {
+    public AddressBook toModelType() {
         AddressBook addressBook = new AddressBook();
 
         for (JsonAdaptedTag jsonAdaptedTag: tags) {
-            Tag tag = jsonAdaptedTag.toModelType();
-            if (addressBook.hasTag(tag)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_TAG);
+            Tag tag;
+            try {
+                tag = jsonAdaptedTag.toModelType();
+                if (addressBook.hasTag(tag)) {
+                    throw new IllegalValueException(MESSAGE_DUPLICATE_TAG);
+                }
+            } catch (IllegalValueException e) {
+                continue;
             }
             addressBook.addTag(tag);
         }

--- a/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
@@ -2,12 +2,14 @@ package seedu.contax.storage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import seedu.contax.commons.core.LogsCenter;
 import seedu.contax.commons.exceptions.IllegalValueException;
 import seedu.contax.model.AddressBook;
 import seedu.contax.model.ReadOnlyAddressBook;
@@ -22,6 +24,7 @@ class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
     public static final String MESSAGE_DUPLICATE_TAG = "Tag list contains duplicate tag(s).";
+    private static final Logger logger = LogsCenter.getLogger(JsonSerializableAddressBook.class);
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
@@ -60,6 +63,7 @@ class JsonSerializableAddressBook {
                     throw new IllegalValueException(MESSAGE_DUPLICATE_TAG);
                 }
             } catch (IllegalValueException e) {
+                logger.fine("Skipped Tag: " + jsonAdaptedTag.getTagNameString());
                 continue;
             }
             addressBook.addTag(tag);
@@ -74,6 +78,7 @@ class JsonSerializableAddressBook {
                     throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
                 }
             } catch (IllegalValueException e) {
+                logger.fine("Skipped Person: " + jsonAdaptedPerson.getPersonNameString());
                 continue;
             }
 

--- a/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/contax/storage/JsonSerializableAddressBook.java
@@ -62,11 +62,11 @@ class JsonSerializableAddressBook {
                 if (addressBook.hasTag(tag)) {
                     throw new IllegalValueException(MESSAGE_DUPLICATE_TAG);
                 }
+                addressBook.addTag(tag);
             } catch (IllegalValueException e) {
                 logger.fine("Skipped Tag: " + jsonAdaptedTag.getTagNameString());
                 continue;
             }
-            addressBook.addTag(tag);
         }
 
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
@@ -77,14 +77,13 @@ class JsonSerializableAddressBook {
                     //skip instead of throwing exception
                     throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
                 }
+                // Load tags that were not added from tag list
+                addMissingTags(person, addressBook);
+                addressBook.addPerson(person);
             } catch (IllegalValueException e) {
                 logger.fine("Skipped Person: " + jsonAdaptedPerson.getPersonNameString());
                 continue;
             }
-
-            // Load tags that were not added from tag list
-            addMissingTags(person, addressBook);
-            addressBook.addPerson(person);
         }
         return addressBook;
     }

--- a/src/test/java/seedu/contax/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/contax/storage/JsonAddressBookStorageTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.contax.commons.exceptions.DataConversionException;
 import seedu.contax.model.AddressBook;
 import seedu.contax.model.ReadOnlyAddressBook;
+import seedu.contax.model.person.Person;
+import seedu.contax.testutil.AddressBookBuilder;
+import seedu.contax.testutil.PersonBuilder;
 
 public class JsonAddressBookStorageTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonAddressBookStorageTest");
@@ -51,13 +54,23 @@ public class JsonAddressBookStorageTest {
     }
 
     @Test
-    public void readAddressBook_invalidPersonAddressBook_throwDataConversionException() {
-        assertThrows(DataConversionException.class, () -> readAddressBook("invalidPersonAddressBook.json"));
+    public void readAddressBook_invalidPersonAddressBook_personSkipped() throws Exception {
+        ReadOnlyAddressBook addressBook = readAddressBook("invalidPersonAddressBook.json").get();
+
+        assertEquals(0, addressBook.getPersonList().size());
     }
 
     @Test
-    public void readAddressBook_invalidAndValidPersonAddressBook_throwDataConversionException() {
-        assertThrows(DataConversionException.class, () -> readAddressBook("invalidAndValidPersonAddressBook.json"));
+    public void readAddressBook_invalidAndValidPersonAddressBook_personSkipped() throws Exception {
+        ReadOnlyAddressBook addressBook = readAddressBook("invalidAndValidPersonAddressBook.json").get();
+        Person exepctedPerson = new PersonBuilder()
+                .withName("Valid Person")
+                .withPhone("9482424")
+                .withEmail("hans@example.com")
+                .withAddress("4th street")
+                .build();
+        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(exepctedPerson).build();
+        assertEquals(addressBook, expectedAddressBook);
     }
 
     @Test

--- a/src/test/java/seedu/contax/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/contax/storage/JsonSerializableAddressBookTest.java
@@ -1,14 +1,12 @@
 package seedu.contax.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.contax.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.contax.commons.exceptions.IllegalValueException;
 import seedu.contax.commons.util.JsonUtil;
 import seedu.contax.model.AddressBook;
 import seedu.contax.testutil.TypicalPersons;
@@ -44,18 +42,21 @@ public class JsonSerializableAddressBookTest {
     }
 
     @Test
-    public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
+    public void toModelType_invalidPersonFile_recordSkipped() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_PERSON_FILE,
                 JsonSerializableAddressBook.class).get();
-        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        assertEquals(0, addressBookFromFile.getPersonList().size());
+        assertEquals(0, addressBookFromFile.getTagList().size());
     }
 
     @Test
-    public void toModelType_duplicatePersons_throwsIllegalValueException() throws Exception {
+    public void toModelType_duplicatePersons_recordSkipped() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
                 JsonSerializableAddressBook.class).get();
-        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON,
-                dataFromFile::toModelType);
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        assertEquals(1, addressBookFromFile.getPersonList().size());
+        assertEquals(1, addressBookFromFile.getTagList().size());
     }
 
     @Test
@@ -69,10 +70,10 @@ public class JsonSerializableAddressBookTest {
     }
 
     @Test
-    public void toModelType_duplicateTags_throwIllegalValueException() throws Exception {
+    public void toModelType_duplicateTags_tagsSkipped() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_TAGS_FILE,
                 JsonSerializableAddressBook.class).get();
-        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
-
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        assertEquals(1, addressBookFromFile.getTagList().size());
     }
 }


### PR DESCRIPTION
# Purpose
This PR is to change the person parsing from `.json` to be more forgiving, such that it skips invalid Persons only instead of loading an entirely new AddressBook.

Same fix applied for tags, and relevant tests are modified to reflect this

# Issues
This closes #253