### PR TITLE
Refactor - Change Command Names and Improve Priority Enum Structure

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -271,11 +271,11 @@ Examples:
 
 ![Find Tags](images/FindTag.png)
 
-### Creating an Appointment : `addappointment`
+### Creating an Appointment : `addappt`
 
 Creates an appointment in the schedule.
 
-Format: `addappointment n/NAME d/DATE t/TIME l/DURATION [p/PERSON]`
+Format: `addappt n/NAME d/DATE t/TIME l/DURATION [p/PERSON]`
 
 * Creates a new appointment with the specified parameters.
 * All parameters except `PERSON` **must** be specified.
@@ -289,36 +289,36 @@ The operation will fail if the appointment **overlaps** with another appointment
 </div>
 
 Examples:
-* `addappointment n/Bi-Weekly Meeting d/14-02-2022 t/11:00 l/60` Creates a *one-hour* appointment named *"Bi-Weekly Meeting"* on *14th Feb 2022* at *11:00 AM*, associated with nobody in the contact list.
-* `addappointment n/Contract Signing With Charlie d/22-10-2022 t/16:30 p/1 l/300` Creates a *5-hour* appointment named *"Contract Signing With Charlie"* on *22nd Oct 2022* at *4:30 PM*, associated with the *first* person in the contact list.
+* `addappt n/Bi-Weekly Meeting d/14-02-2022 t/11:00 l/60` Creates a *one-hour* appointment named *"Bi-Weekly Meeting"* on *14th Feb 2022* at *11:00 AM*, associated with nobody in the contact list.
+* `addappt n/Contract Signing With Charlie d/22-10-2022 t/16:30 p/1 l/300` Creates a *5-hour* appointment named *"Contract Signing With Charlie"* on *22nd Oct 2022* at *4:30 PM*, associated with the *first* person in the contact list.
 
-### Listing All Appointments : `listappointments`
+### Listing All Appointments : `listappt`
 
 Shows a list of all appointments in the schedule.
 
-Format: `listappointments`
+Format: `listappt`
 
 **Example output**
 
 ![List Appointments Result](images/ListAppointments.png)
 
-### Deleting an Appointment : `deleteappointment`
+### Deleting an Appointment : `deleteappt`
 
 Deletes an appointment previously created in the schedule.
 
-Format: `deleteappointment INDEX`
+Format: `deleteappt INDEX`
 
 * Deletes the appointment that is at `INDEX` in the appointment list.
 * The `INDEX` parameter **must be a positive integer**, and refers to the index number shown in the **displayed appointment list**.
 
 Examples:
-* `deleteappointment 2` Deletes the *second* appointment in the list of appointments.
+* `deleteappt 2` Deletes the *second* appointment in the list of appointments.
 
-### Editing an Appointment : `editappointment`
+### Editing an Appointment : `editappt`
 
 Edits an appointment previously created in the schedule.
 
-Format: `editappointment INDEX [n/NAME] [d/DATE] [t/TIME] [p/PERSON] [l/DURATION]`
+Format: `editappt INDEX [n/NAME] [d/DATE] [t/TIME] [p/PERSON] [l/DURATION]`
 
 * Edits the appointment that is at `INDEX` in the appointment list, setting the supplied parameter(s) to the supplied value(s).
 * The `INDEX` parameter **must be a positive integer**, and refers to the index number shown in the **displayed appointment list**.
@@ -334,15 +334,15 @@ The operation will fail if the modified appointment **overlaps** with another ap
 </div>
 
 Examples:
-* `editappointment 6 l/300 p/none` Edits the *6th* appointment in the list of appointments to have a duration of *5 hours*, and removes the person associated with the appointment. No other properties are changed.
-* `editappointment 2 n/Call Juliet t/13:45 p/1` Edits the *second* appointment in the list of appointments to have the name *"Call Juliet"*, changes the time to *1:45 PM* and associates the appointment to the first person in the displayed persons list. No other properties are changed.
+* `editappt 6 l/300 p/none` Edits the *6th* appointment in the list of appointments to have a duration of *5 hours*, and removes the person associated with the appointment. No other properties are changed.
+* `editappt 2 n/Call Juliet t/13:45 p/1` Edits the *second* appointment in the list of appointments to have the name *"Call Juliet"*, changes the time to *1:45 PM* and associates the appointment to the first person in the displayed persons list. No other properties are changed.
 
-### Listing Appointments Within A Period : `appointmentsbetween`
+### Listing Appointments Within A Period : `apptbetween`
 
 Lists all appointments from a starting time to an ending time inclusive of both ends of the range.
 It will list all appointments that contain any sub-range of the provided period.
 
-Format: `appointmentsbetween [sd/STARTDATE] [st/STARTTIME] [ed/ENDDATE [et/ENDTIME]]`
+Format: `apptbetween [sd/STARTDATE] [st/STARTTIME] [ed/ENDDATE [et/ENDTIME]]`
 
 * The starting time **must be before** the ending time.
 * The `STARTDATE` parameter denotes the *starting date* of the period.
@@ -358,7 +358,7 @@ Format: `appointmentsbetween [sd/STARTDATE] [st/STARTTIME] [ed/ENDDATE [et/ENDTI
 * If `ENDTIME` is specified, then `ENDDATE` must be specified.
 
 Example:
-* `appointmentsbetween sd/21-10-2022 st/12:00 ed/23-10-2022 et/17:00` Lists all appointments from *21 October 2022, 12 PM* to *23 October 2022, 5PM*.
+* `apptbetween sd/21-10-2022 st/12:00 ed/23-10-2022 et/17:00` Lists all appointments from *21 October 2022, 12 PM* to *23 October 2022, 5PM*.
 
 **Example Output:**
 
@@ -510,9 +510,9 @@ Format: `COMMAND_A && COMMAND_B`
 * A valid command must be supplied before and after the `&&` operator, otherwise the command will fail
 
 Examples:
-* `editappointment 6 l/360 && listappointments`
+* `editappt 6 l/360 && listappt`
     * Edits the 6th appointment in the list of appointments to have a duration of 6 hours. Then list all appointments in the Schedule
-* `deleteappointment 2 && addappointment n/Contract Signing With Charlie d/22-10-2022 t/16:30 p/1 l/300`
+* `deleteappt 2 && addappt n/Contract Signing With Charlie d/22-10-2022 t/16:30 p/1 l/300`
     * Deletes the 2nd appointment in the list of appointments.
     * Then, create a 5-hour appointment named "Contract Signing With Charlie" on 22nd Oct 2022 at 4:30 PM, associated with the first person in the contact list
 
@@ -541,15 +541,15 @@ Action | Format, Examples
 **List Tags** | `listtags`
 **Delete Tag** | `deletetag INDEX` <br> e.g., `deletetag 1`
 **Find Contacts By Tag** | `findbytag t/TAGNAME` <br> e.g., `findbytag t/friends`
-**Add Appointment** | `addappointment n/NAME d/DATE t/TIME l/DURATION p/PERSON`<br> e.g., `addappointment n/Call Bob d/14-02-2022 t/11:00 p/2 l/60`
-**List Appointments** | `listappointments`
-**Delete Appointment** | `deleteappointment INDEX`<br> e.g., `deleteappointment 2`
-**Edit Appointment** | `editappointment INDEX [n/NAME] [d/DATE] [t/TIME] [p/PERSON] [l/DURATION]`<br> e.g., `editappointment 2 n/Call Juliet t/13:45`
-**List Appointments Within Period** | `appointmentsbetween [sd/STARTDATE] [st/STARTTIME] [ed/ENDDATE [et/ENDTIME]]` <br> e.g. `appointmentsbetween sd/21-10-2022 st/12:00 ed/23-10-2022 et/17:00`
+**Add Appointment** | `addappt n/NAME d/DATE t/TIME l/DURATION p/PERSON`<br> e.g., `addappt n/Call Bob d/14-02-2022 t/11:00 p/2 l/60`
+**List Appointments** | `listappt`
+**Delete Appointment** | `deleteappt INDEX`<br> e.g., `deleteappt 2`
+**Edit Appointment** | `editappt INDEX [n/NAME] [d/DATE] [t/TIME] [p/PERSON] [l/DURATION]`<br> e.g., `editappt 2 n/Call Juliet t/13:45`
+**List Appointments Within Period** | `apptbetween [sd/STARTDATE] [st/STARTTIME] [ed/ENDDATE [et/ENDTIME]]` <br> e.g. `apptbetween sd/21-10-2022 st/12:00 ed/23-10-2022 et/17:00`
 **List Available Slots Within Period** | `freebetween l/DURATION [sd/STARTDATE] [st/STARTTIME] [ed/ENDDATE [et/ENDTIME]]` <br> e.g. `freebetween sd/21-10-2022 st/12:00 ed/23-10-2022 et/17:00 l/60`
 **Help** | `help`
 **Export CSV** | `exportcsv`
 **Import CSV** | `importcsv f/FILEPATH [n/COLUMNNUM] [p/COLUMN_PERSON] [e/COLUMN_EMAIL] [a/COLUMN_ADDRESS] [t/COLUMN_TAGS]` <br> e.g., `importCSV n/2 p/3 e/5 a/6 t/4`
 **Operate on Contacts by Conditional Clause** | `batch COMMAND where/CONDITION` <br> e.g., `batch Edit p/87438806 where/ p/Phone = 87438807`
 **Operate on Contacts within Range** | `range COMMAND from/INDEX to/INDEX` <br> e.g., `range editperson e/johndoe@example.com from/6 to/10`
-**Chaining Commands** | `chain COMMAND_A && COMMAND_B` <br> e.g., `chain editappointment 6 l/360 && listappointments`
+**Chaining Commands** | `chain COMMAND_A && COMMAND_B` <br> e.g., `chain editappt 6 l/360 && listappt`

--- a/src/main/java/seedu/contax/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/AddAppointmentCommand.java
@@ -22,7 +22,7 @@ import seedu.contax.model.person.Person;
  */
 public class AddAppointmentCommand extends Command {
 
-    public static final String COMMAND_WORD = "addappointment";
+    public static final String COMMAND_WORD = "addappt";
 
     public static final String MESSAGE_USAGE = "`" + COMMAND_WORD + "`: **Adds an appointment to the schedule.** "
             + "\nParameters: *"

--- a/src/main/java/seedu/contax/logic/commands/AppointmentsBetweenCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/AppointmentsBetweenCommand.java
@@ -19,7 +19,7 @@ import seedu.contax.model.chrono.DateRangePredicate;
  */
 public class AppointmentsBetweenCommand extends Command {
 
-    public static final String COMMAND_WORD = "appointmentsbetween";
+    public static final String COMMAND_WORD = "apptbetween";
     public static final String MESSAGE_USAGE = "`" + COMMAND_WORD + "`: **Lists appointments within a period.** "
             + "\nParameters: *"
             + "[" + PREFIX_DATE_START + "STARTDATE] "

--- a/src/main/java/seedu/contax/logic/commands/DeleteAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/DeleteAppointmentCommand.java
@@ -15,7 +15,7 @@ import seedu.contax.model.appointment.Appointment;
  */
 public class DeleteAppointmentCommand extends Command {
 
-    public static final String COMMAND_WORD = "deleteappointment";
+    public static final String COMMAND_WORD = "deleteappt";
 
     public static final String MESSAGE_USAGE = "`" + COMMAND_WORD
             + "`: **Deletes the appointment identified by the index number used in the displayed appointment list.**"

--- a/src/main/java/seedu/contax/logic/commands/EditAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/EditAppointmentCommand.java
@@ -32,7 +32,7 @@ import seedu.contax.model.person.Person;
  */
 public class EditAppointmentCommand extends Command {
 
-    public static final String COMMAND_WORD = "editappointment";
+    public static final String COMMAND_WORD = "editappt";
 
     public static final String MESSAGE_USAGE = "`" + COMMAND_WORD + "`: **Edits the details of the appointment "
             + "identified by the index number used in the displayed appointment list. "

--- a/src/main/java/seedu/contax/logic/commands/EditAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/EditAppointmentCommand.java
@@ -132,7 +132,6 @@ public class EditAppointmentCommand extends Command {
         }
 
         Priority originalPriority = appointmentToEdit.getPriority();
-
         return new Appointment(updatedName, updatedStartDateTime, updatedDuration, updatedPerson, originalPriority);
     }
 

--- a/src/main/java/seedu/contax/logic/commands/FindAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/FindAppointmentCommand.java
@@ -12,7 +12,7 @@ import seedu.contax.model.appointment.ContainsKeywordsPredicate;
  * Keyword matching is case-insensitive.
  */
 public class FindAppointmentCommand extends Command {
-    public static final String COMMAND_WORD = "findappointment";
+    public static final String COMMAND_WORD = "findappt";
 
     public static final String MESSAGE_USAGE = "`" + COMMAND_WORD + "`: Finds all appointments with"
             + "names or person names that "

--- a/src/main/java/seedu/contax/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/ListAppointmentCommand.java
@@ -11,7 +11,7 @@ import seedu.contax.model.Model;
  */
 public class ListAppointmentCommand extends Command {
 
-    public static final String COMMAND_WORD = "listappointments";
+    public static final String COMMAND_WORD = "listappt";
 
     public static final String MESSAGE_SUCCESS = "Listed all appointments";
 

--- a/src/main/java/seedu/contax/model/appointment/Appointment.java
+++ b/src/main/java/seedu/contax/model/appointment/Appointment.java
@@ -25,7 +25,7 @@ public class Appointment extends ScheduleItem {
     private final Priority priority;
 
     /**
-     * Constructs an {@code Appointment}.
+     * Constructs an {@code Appointment} without a priority level.
      * The fields {@code name, startDateTime, duration} must be present and not null.
      * The {@code person} argument is optional, and may be null.
      *
@@ -35,29 +35,22 @@ public class Appointment extends ScheduleItem {
      * @param person A valid Person or null.
      */
     public Appointment(Name name, StartDateTime startDateTime, Duration duration, Person person) {
-        super(Appointment.getStartDateTimeOrThrow(startDateTime),
-                Appointment.computeEndDateTime(startDateTime, duration));
-        requireNonNull(name);
-
-        this.name = name;
-        this.startDateTime = startDateTime;
-        this.duration = duration;
-        this.person = person;
-        this.priority = null;
+        this(name, startDateTime, duration, person, null);
     }
 
     /**
-     * Constructs an {@code Appointment} with additional attribute priority.
+     * Constructs an {@code Appointment} with a priority level.
      * The fields {@code name, startDateTime, duration} must be present and not null.
-     * The fields {@code priority} is optional and may be null.
+     * The fields {@code person, priority} are optional and may be null.
      *
      * @param name A valid Appointment Name.
      * @param startDateTime A valid Appointment Starting DateTime.
      * @param duration A valid Appointment Duration.
      * @param person A valid Person or null.
-     * @param priority A valid priority level or null.
+     * @param priority A valid Priority level or null.
      */
-    public Appointment(Name name, StartDateTime startDateTime, Duration duration, Person person, Priority priority) {
+    public Appointment(Name name, StartDateTime startDateTime, Duration duration, Person person,
+                       Priority priority) {
         super(Appointment.getStartDateTimeOrThrow(startDateTime),
                 Appointment.computeEndDateTime(startDateTime, duration));
         requireNonNull(name);
@@ -94,6 +87,12 @@ public class Appointment extends ScheduleItem {
         return priority;
     }
 
+    /**
+     * Creates a new {@code Appointment} instance with the supplied {@code Priority} level.
+     *
+     * @param priority The new priority level to assign to this Appointment.
+     * @return A new immutable instance of Appointment with the updated Priority.
+     */
     public Appointment withPriority(Priority priority) {
         return new Appointment(name, startDateTime, duration, person, priority);
     }

--- a/src/main/java/seedu/contax/model/appointment/Priority.java
+++ b/src/main/java/seedu/contax/model/appointment/Priority.java
@@ -1,21 +1,46 @@
 package seedu.contax.model.appointment;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents an {@link Appointment}'s priority
  **/
 
 public enum Priority {
-    LOW,
-    MEDIUM,
-    HIGH;
+    LOW("Low"),
+    MEDIUM("Medium"),
+    HIGH("High");
+
+    private final String displayName;
+
+    /**
+     * Constructs a Priority level.
+     */
+    Priority(String displayName) {
+        this.displayName = displayName;
+    }
 
     @Override
     public String toString() {
-        switch(this) {
-        case LOW: return "Low";
-        case MEDIUM: return "Medium";
-        case HIGH: return "High";
-        default: return "None";
+        return this.displayName;
+    }
+
+    /**
+     * Returns the Priority Enum with the supplied display name.
+     *
+     * @param displayName The display name to match for enums against.
+     * @return The corresponding enum, or null if no priority levels match the supplied.
+     */
+    public static Priority getFromDisplayName(String displayName) {
+        requireNonNull(displayName);
+        if (displayName.equalsIgnoreCase(LOW.displayName)) {
+            return LOW;
+        } else if (displayName.equalsIgnoreCase(MEDIUM.displayName)) {
+            return MEDIUM;
+        } else if (displayName.equalsIgnoreCase(HIGH.displayName)) {
+            return HIGH;
+        } else {
+            return null;
         }
     }
 }

--- a/src/main/java/seedu/contax/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/contax/storage/JsonAdaptedAppointment.java
@@ -137,23 +137,14 @@ class JsonAdaptedAppointment {
      * Performs the validation and parsing of Appointment priority into a {@code Priority} model.
      */
     private Priority parsePriorityModel() throws IllegalValueException {
-        Priority modelPriority = null;
-        if (priority != null) {
-            switch (priority) {
-            case "High":
-                modelPriority = Priority.HIGH;
-                break;
-            case "Medium":
-                modelPriority = Priority.MEDIUM;
-                break;
-            case "Low":
-                modelPriority = Priority.LOW;
-                break;
-            default:
-                throw new IllegalValueException(INVALID_PRIORITY_MESSAGE);
-            }
-            return modelPriority;
+        if (priority == null) {
+            return null;
         }
-        return null;
+
+        Priority modelPriority = Priority.getFromDisplayName(priority);
+        if (modelPriority == null) {
+            throw new IllegalValueException(INVALID_PRIORITY_MESSAGE);
+        }
+        return modelPriority;
     }
 }

--- a/src/main/java/seedu/contax/ui/appointment/cardfactory/AppointmentCard.java
+++ b/src/main/java/seedu/contax/ui/appointment/cardfactory/AppointmentCard.java
@@ -98,22 +98,25 @@ class AppointmentCard extends UiPart<Region> {
     }
 
     private void updatePriorityStyle(Priority modelPriority) {
+        priority.getStyleClass().remove("high");
+        priority.getStyleClass().remove("medium");
+        priority.getStyleClass().remove("low");
+
         if (appointmentModel.getPriority() != null) {
             priority.setText(modelPriority.toString());
             switch (appointmentModel.getPriority()) {
             case HIGH:
-                priority.setStyle("-fx-background-color: red;");
+                priority.getStyleClass().add("high");
                 break;
             case MEDIUM:
-                priority.setStyle("-fx-background-color: orange ;");
+                priority.getStyleClass().add("medium");
                 break;
             default:
-                priority.setStyle("-fx-background-color: green;");
+                priority.getStyleClass().add("low");
                 break;
             }
         } else {
             priority.setText("");
-            priority.setStyle("-fx-background-color: none;");
         }
     }
 

--- a/src/main/resources/view/AppointmentListCard.fxml
+++ b/src/main/resources/view/AppointmentListCard.fxml
@@ -27,7 +27,12 @@
           </minWidth>
         </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$name" wrapText="true" />
-        <Label fx:id="priority" alignment="CENTER" minWidth="90" styleClass="priority-text" wrapText="true" />
+        <Label fx:id="priority" text="\$priority" styleClass="priority_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
       </HBox>
       <HBox alignment="CENTER_LEFT">
         <padding>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -404,3 +404,24 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+.priority_label {
+    -fx-text-fill: #CCCCCC;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 12;
+    -fx-font-family: "Segoe UI Semibold";
+}
+
+.priority_label.low {
+    -fx-background-color: #3e9161;
+}
+
+.priority_label.medium {
+    -fx-background-color: #3e7b91;
+}
+
+.priority_label.high {
+    -fx-background-color: #913e3e;
+}

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -18,10 +18,3 @@
 .tooltip-text {
     -fx-text-fill: white;
 }
-
-.priority-text {
-    -fx-font-size: 12px;
-    -fx-padding: 2;
-    -fx-background-radius: 50;
-    -fx-font-family: "Segoe UI Semibold";
-}

--- a/src/test/java/seedu/contax/model/appointment/PriorityTest.java
+++ b/src/test/java/seedu/contax/model/appointment/PriorityTest.java
@@ -1,0 +1,24 @@
+package seedu.contax.model.appointment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class PriorityTest {
+    @Test
+    public void testGetFromName() {
+        assertEquals(Priority.LOW, Priority.getFromDisplayName("LOW"));
+        assertEquals(Priority.LOW, Priority.getFromDisplayName("low"));
+        assertEquals(Priority.MEDIUM, Priority.getFromDisplayName("medium"));
+        assertEquals(Priority.HIGH, Priority.getFromDisplayName("high"));
+        assertNull(Priority.getFromDisplayName("something"));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("High", Priority.HIGH.toString());
+        assertEquals("Medium", Priority.MEDIUM.toString());
+        assertEquals("Low", Priority.LOW.toString());
+    }
+}


### PR DESCRIPTION
## Changes
This PR renames all the appointment commands to shorten the command word. It also refines the structure of the appointment priority, and streamlines the UI to be more consistent with the current look-and-feel.

## Related Issues
- Closes #257