### PR TITLE
Bugfix - Phone number not allowing numbers starting with 0

### DIFF
--- a/src/main/java/seedu/contax/model/person/Phone.java
+++ b/src/main/java/seedu/contax/model/person/Phone.java
@@ -13,7 +13,7 @@ public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers and country code (optional), and "
                     + "at least 3 digits long";
-    public static final String VALIDATION_REGEX = "^([0|\\+[0-9]{1,5}])?([0-9][0-9]{2,})$";
+    public static final String VALIDATION_REGEX = "^([0|\\+[0-9]{1,5}])?([0-9]{3,})$";
     public final String value;
 
     /**

--- a/src/main/java/seedu/contax/model/person/Phone.java
+++ b/src/main/java/seedu/contax/model/person/Phone.java
@@ -13,7 +13,7 @@ public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers and country code (optional), and "
                     + "at least 3 digits long";
-    public static final String VALIDATION_REGEX = "^([0|\\+[0-9]{1,5}])?([1-9][0-9]{2,})$";
+    public static final String VALIDATION_REGEX = "^([0|\\+[0-9]{1,5}])?([0-9][0-9]{2,})$";
     public final String value;
 
     /**


### PR DESCRIPTION
# Purpose
This PR changes the `Phone` regex checker to allow phone numbers starting with 0

# Related Issues
This closes #287 