### PR TITLE
Small UG formatting fix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,7 +61,7 @@ ContaX is generally designed to impose as little constraints on inputs as possib
 * **INTEGER** inputs are limited to a maximum value of `2,147,483,647`.<br>
   Any value above this limit will not be considered an integer.
 * Leading and Trailing **Whitespaces** are ignored for ***ALL*** user inputs.<br>
-  e.g. `  My Tag   &nbsp;\` is treated simply as `My Tag`.
+  e.g. `My Tag   &nbsp; ` is treated simply as `My Tag`.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,7 +61,7 @@ ContaX is generally designed to impose as little constraints on inputs as possib
 * **INTEGER** inputs are limited to a maximum value of `2,147,483,647`.<br>
   Any value above this limit will not be considered an integer.
 * Leading and Trailing **Whitespaces** are ignored for ***ALL*** user inputs.<br>
-  e.g. `My Tag   &nbsp;`` is treated simply as `My Tag`.
+  e.g. `My Tag   &nbsp;``` is treated simply as `My Tag`.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,7 +61,7 @@ ContaX is generally designed to impose as little constraints on inputs as possib
 * **INTEGER** inputs are limited to a maximum value of `2,147,483,647`.<br>
   Any value above this limit will not be considered an integer.
 * Leading and Trailing **Whitespaces** are ignored for ***ALL*** user inputs.<br>
-  e.g. `  My Tag   &nbsp;` is treated simply as `My Tag`.
+  e.g. `  My Tag   &nbsp;\` is treated simply as `My Tag`.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,7 +61,7 @@ ContaX is generally designed to impose as little constraints on inputs as possib
 * **INTEGER** inputs are limited to a maximum value of `2,147,483,647`.<br>
   Any value above this limit will not be considered an integer.
 * Leading and Trailing **Whitespaces** are ignored for ***ALL*** user inputs.<br>
-  e.g. `My Tag   &nbsp; ` is treated simply as `My Tag`.
+  e.g. `My Tag   &nbsp;`` is treated simply as `My Tag`.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,7 +61,7 @@ ContaX is generally designed to impose as little constraints on inputs as possib
 * **INTEGER** inputs are limited to a maximum value of `2,147,483,647`.<br>
   Any value above this limit will not be considered an integer.
 * Leading and Trailing **Whitespaces** are ignored for ***ALL*** user inputs.<br>
-  e.g. `My Tag   &nbsp;``` is treated simply as `My Tag`.
+  e.g. `My Tag   &nbsp;` is treated simply as `My Tag`.
 
 </div>
 


### PR DESCRIPTION
This PR resolves #313. It's some random markdown quirk where theres a space in front of the backtick.

If we want to show how the space at the front will also be trimmed, one possibility is to show 2 separate examples, or escape the spaces (?)