### PR TITLE
Fix - Reset mechanism in Address Book

### DIFF
--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -3,6 +3,7 @@ package seedu.contax.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -47,10 +48,13 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// list overwrite operations
 
     /**
-     * Replaces the contents of the person list with {@code persons}.
+     * Replaces the contents of the person list with {@code persons} and adds any tags that does not exist in the tag
+     * list.
      * {@code persons} must not contain duplicate persons.
      */
     public void setPersons(List<Person> persons) {
+        persons.forEach(this::addTagsNotInList);
+
         this.persons.setPersons(persons);
     }
 
@@ -64,8 +68,10 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
-        setPersons(newData.getPersonList());
+        // Duplicate check not required as ReadOnlyAddressBook ensures unique tags and persons
+        // Ensures all tags are added first.
         setTags(newData.getTagList());
+        setPersons(newData.getPersonList());
     }
 
     //// person-level operations

--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -57,7 +57,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         this.persons.setPersons(persons);
     }
 
+    /**
+     * Replaces the contents of the tag list with {@code tags} and strips tags in persons that are not in {@code tags}.
+     */
     public void setTags(List<Tag> tags) {
+        persons.forEach(p -> stripTagsFromPerson(p, tags));
         this.tags.setTags(tags);
     }
 
@@ -190,6 +194,21 @@ public class AddressBook implements ReadOnlyAddressBook {
             Person editedPerson = person.withoutTag(target).withTag(editedTag);
             setPerson(person, editedPerson);
         }
+    }
+
+    /**
+     * Removes all tags from {@code person} if the tag does not exist in {@code tagList}.
+     */
+    private void stripTagsFromPerson(Person person, List<Tag> tagList) {
+        Set<Tag> personTags = person.getTags();
+
+        Person newPerson = person;
+        for (Tag pTag : personTags) {
+            if (!tagList.contains(pTag)) {
+                newPerson = newPerson.withoutTag(pTag);
+            }
+        }
+        setPerson(person, newPerson);
     }
 
     //// util methods

--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -59,6 +59,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     /**
      * Replaces the contents of the tag list with {@code tags} and strips tags in persons that are not in {@code tags}.
+     * {@code tags} must not contain duplicate tags.
      */
     public void setTags(List<Tag> tags) {
         persons.forEach(p -> stripTagsFromPerson(p, tags));

--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -3,7 +3,6 @@ package seedu.contax.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/src/main/java/seedu/contax/model/AddressBook.java
+++ b/src/main/java/seedu/contax/model/AddressBook.java
@@ -52,6 +52,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code persons} must not contain duplicate persons.
      */
     public void setPersons(List<Person> persons) {
+        requireNonNull(persons);
+
         persons.forEach(this::addTagsNotInList);
 
         this.persons.setPersons(persons);
@@ -62,6 +64,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code tags} must not contain duplicate tags.
      */
     public void setTags(List<Tag> tags) {
+        requireNonNull(tags);
+
         persons.forEach(p -> stripTagsFromPerson(p, tags));
         this.tags.setTags(tags);
     }

--- a/src/test/java/seedu/contax/model/AddressBookTest.java
+++ b/src/test/java/seedu/contax/model/AddressBookTest.java
@@ -8,6 +8,7 @@ import static seedu.contax.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.contax.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
+import static seedu.contax.testutil.TypicalPersons.BENSON;
 import static seedu.contax.testutil.TypicalPersons.BOB;
 import static seedu.contax.testutil.TypicalPersons.CARL;
 import static seedu.contax.testutil.TypicalPersons.FIONA;
@@ -16,6 +17,7 @@ import static seedu.contax.testutil.TypicalPersons.GEORGE;
 import static seedu.contax.testutil.TypicalPersons.HOON;
 import static seedu.contax.testutil.TypicalPersons.OWES_MONEY;
 import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.contax.testutil.TypicalPersons.getTypicalTags;
 import static seedu.contax.testutil.TypicalTags.CLIENTS;
 import static seedu.contax.testutil.TypicalTags.COLLEAGUES;
 
@@ -143,6 +145,53 @@ public class AddressBookTest {
                         .withPerson(fiona).withPerson(george).build();
 
         addressBook.setPersons(personList);
+        assertEquals(expectedAddressBook, addressBook);
+    }
+
+    @Test
+    public void setTags_personTagsDoesNotExist_stripTag() {
+        // Empty tag list - Strip all
+        AddressBook addressBook = new AddressBookBuilder().withTag(FRIENDS).withPerson(ALICE).build();
+        List<Tag> emptyList = List.of();
+        addressBook.setTags(emptyList);
+        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(ALICE.withoutTag(FRIENDS)).build();
+
+        assertEquals(expectedAddressBook, addressBook);
+
+
+        // Strip only missing tags
+        addressBook =
+                new AddressBookBuilder().withTag(FRIENDS).withTag(OWES_MONEY)
+                        .withPerson(ALICE).withPerson(BENSON).build();
+
+        List<Tag> tagList = List.of(FRIENDS);
+
+        // OWES_MONEY should be removed
+        addressBook.setTags(tagList);
+        expectedAddressBook =
+                new AddressBookBuilder().withTag(FRIENDS).withPerson(ALICE)
+                        .withPerson(BENSON.withoutTag(OWES_MONEY)).build();
+
+        assertEquals(expectedAddressBook, addressBook);
+    }
+
+    @Test
+    public void setTags_allTagsExist_noStripping() {
+        // Exactly the same as previous address book
+        AddressBook addressBook = getTypicalAddressBook();
+        List<Tag> tagList = getTypicalTags();
+
+        addressBook.setTags(tagList);
+        AddressBook expectedAddressBook = getTypicalAddressBook();
+        assertEquals(expectedAddressBook, addressBook);
+
+        // Tag not associated with any persons
+        addressBook = getTypicalAddressBook();
+        tagList = List.of(FRIENDS, OWES_MONEY);
+        addressBook.setTags(tagList);
+
+        expectedAddressBook = getTypicalAddressBook();
+        expectedAddressBook.removeTag(COLLEAGUES);
         assertEquals(expectedAddressBook, addressBook);
     }
 

--- a/src/test/java/seedu/contax/model/AddressBookTest.java
+++ b/src/test/java/seedu/contax/model/AddressBookTest.java
@@ -11,8 +11,10 @@ import static seedu.contax.testutil.TypicalPersons.ALICE;
 import static seedu.contax.testutil.TypicalPersons.BOB;
 import static seedu.contax.testutil.TypicalPersons.CARL;
 import static seedu.contax.testutil.TypicalPersons.FRIENDS;
+import static seedu.contax.testutil.TypicalPersons.HOON;
 import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.contax.testutil.TypicalTags.CLIENTS;
+import static seedu.contax.testutil.TypicalTags.COLLEAGUES;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -23,12 +25,14 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.contax.model.person.Address;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.person.exceptions.DuplicatePersonException;
 import seedu.contax.model.person.exceptions.PersonNotFoundException;
 import seedu.contax.model.tag.Tag;
 import seedu.contax.testutil.AddressBookBuilder;
 import seedu.contax.testutil.PersonBuilder;
+import seedu.contax.testutil.TagBuilder;
 
 public class AddressBookTest {
 
@@ -58,6 +62,18 @@ public class AddressBookTest {
         AddressBook newData = getTypicalAddressBook();
         addressBook.resetData(newData);
         assertEquals(newData, addressBook);
+    }
+
+    @Test
+    public void resetData_personHasMissingTag_replacesData() {
+        AddressBook newAB = getTypicalAddressBook();
+        Tag newTag = new TagBuilder().withName("brand new tag").build();
+        Person hoonWithTag = HOON.withTag(newTag);
+        newAB.addTag(newTag);
+        newAB.addPerson(hoonWithTag);
+
+        addressBook.resetData(newAB);
+        assertEquals(newAB, addressBook);
     }
 
     @Test

--- a/src/test/java/seedu/contax/model/AddressBookTest.java
+++ b/src/test/java/seedu/contax/model/AddressBookTest.java
@@ -10,8 +10,11 @@ import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
 import static seedu.contax.testutil.TypicalPersons.BOB;
 import static seedu.contax.testutil.TypicalPersons.CARL;
+import static seedu.contax.testutil.TypicalPersons.FIONA;
 import static seedu.contax.testutil.TypicalPersons.FRIENDS;
+import static seedu.contax.testutil.TypicalPersons.GEORGE;
 import static seedu.contax.testutil.TypicalPersons.HOON;
+import static seedu.contax.testutil.TypicalPersons.OWES_MONEY;
 import static seedu.contax.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.contax.testutil.TypicalTags.CLIENTS;
 import static seedu.contax.testutil.TypicalTags.COLLEAGUES;
@@ -25,7 +28,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.contax.model.person.Address;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.person.exceptions.DuplicatePersonException;
 import seedu.contax.model.person.exceptions.PersonNotFoundException;
@@ -107,6 +109,40 @@ public class AddressBookTest {
 
         AddressBook expectedAddressBook =
                 new AddressBookBuilder().withTag(FRIENDS).withPerson(CARL).withPerson(BOB).build();
+        assertEquals(expectedAddressBook, addressBook);
+    }
+
+    @Test
+    public void setPersons_hasMissingTag_success() {
+        // AddressBook should add the missing tag that exists in the person
+        Tag newTag = new TagBuilder().withName("new tag").build();
+        Person hoonWithTag = HOON.withTag(newTag);
+
+        AddressBook expectedAddressBook = new AddressBookBuilder().withTag(newTag).withPerson(hoonWithTag).build();
+
+        List<Person> personList = List.of(hoonWithTag);
+        addressBook.setPersons(personList);
+        assertEquals(expectedAddressBook, addressBook);
+
+    }
+
+    @Test
+    public void setPersons_tagsExist_success() {
+        // AddressBook should not add any tag in the address book
+        AddressBook addressBook = getTypicalAddressBook();
+
+        // FRIENDS and OWES_MONEY already exists in the address book
+        // FIONA and GEORGE chosen as they do not have any tags
+        Person fiona = FIONA.withTag(FRIENDS).withTag(OWES_MONEY);
+        Person george = GEORGE.withTag(FRIENDS);
+
+        List<Person> personList = List.of(fiona, george);
+
+        AddressBook expectedAddressBook =
+                new AddressBookBuilder().withTag(FRIENDS).withTag(OWES_MONEY).withTag(COLLEAGUES)
+                        .withPerson(fiona).withPerson(george).build();
+
+        addressBook.setPersons(personList);
         assertEquals(expectedAddressBook, addressBook);
     }
 

--- a/src/test/java/seedu/contax/model/appointment/NameTest.java
+++ b/src/test/java/seedu/contax/model/appointment/NameTest.java
@@ -54,6 +54,7 @@ public class NameTest {
         Name reference1 = new Name("Work Meeting");
         Name reference2 = new Name("Work Meeting 2");
 
+        assertTrue(reference1.equals(reference1));
         assertTrue(reference1.equals(new Name("Work Meeting")));
         assertTrue(reference2.equals(new Name("Work Meeting 2")));
         assertTrue(reference1.equals(reference1));

--- a/src/test/java/seedu/contax/model/person/AddressTest.java
+++ b/src/test/java/seedu/contax/model/person/AddressTest.java
@@ -33,4 +33,17 @@ public class AddressTest {
         assertTrue(Address.isValidAddress("-")); // one character
         assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
     }
+
+    @Test
+    public void equals() {
+        Address address1 = new Address("13 Computing Drive Singapore 117417");
+        Address address2 = new Address("Blk 456, Den Road, #01-355");
+
+        assertTrue(address1.equals(address1));
+        assertTrue(address1.equals(new Address("13 Computing Drive Singapore 117417")))
+
+        assertFalse(address1.equals(address2));
+        assertFalse(address1.equals(null));
+        assertFalse(address1.equals(0));
+    }
 }

--- a/src/test/java/seedu/contax/model/person/AddressTest.java
+++ b/src/test/java/seedu/contax/model/person/AddressTest.java
@@ -40,7 +40,7 @@ public class AddressTest {
         Address address2 = new Address("Blk 456, Den Road, #01-355");
 
         assertTrue(address1.equals(address1));
-        assertTrue(address1.equals(new Address("13 Computing Drive Singapore 117417")))
+        assertTrue(address1.equals(new Address("13 Computing Drive Singapore 117417")));
 
         assertFalse(address1.equals(address2));
         assertFalse(address1.equals(null));

--- a/src/test/java/seedu/contax/model/person/EmailTest.java
+++ b/src/test/java/seedu/contax/model/person/EmailTest.java
@@ -65,4 +65,17 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
     }
+
+    @Test
+    public void equals() {
+        Email email1 = new Email("johnny@johnny.com");
+        Email email2 = new Email("bravo@bravo.com");
+
+        assertTrue(email1.equals(email1));
+        assertTrue(email1.equals(new Email("johnny@johnny.com")));
+
+        assertFalse(email1.equals(email2));
+        assertFalse(email1.equals(null));
+        assertFalse(email1.equals(0));
+    }
 }

--- a/src/test/java/seedu/contax/model/person/PhoneTest.java
+++ b/src/test/java/seedu/contax/model/person/PhoneTest.java
@@ -37,4 +37,17 @@ public class PhoneTest {
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
     }
+
+    @Test
+    public void equals() {
+        Phone phone1 = new Phone("91234567");
+        Phone phone2 = new Phone("12345679");
+
+        assertTrue(phone1.equals(phone1));
+        assertTrue(phone1.equals(new Phone("91234567")));
+
+        assertFalse(phone1.equals(phone2));
+        assertFalse(phone1.equals(null));
+        assertFalse(phone1.equals(0));
+    }
 }

--- a/src/test/java/seedu/contax/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/contax/model/person/UniquePersonListTest.java
@@ -9,7 +9,6 @@ import static seedu.contax.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
 import static seedu.contax.testutil.TypicalPersons.BOB;
-import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.contax.model.person.exceptions.DuplicatePersonException;
 import seedu.contax.model.person.exceptions.PersonNotFoundException;
-import seedu.contax.model.tag.UniqueTagList;
 import seedu.contax.testutil.PersonBuilder;
 
 public class UniquePersonListTest {

--- a/src/test/java/seedu/contax/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/contax/model/person/UniquePersonListTest.java
@@ -9,6 +9,7 @@ import static seedu.contax.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.contax.testutil.Assert.assertThrows;
 import static seedu.contax.testutil.TypicalPersons.ALICE;
 import static seedu.contax.testutil.TypicalPersons.BOB;
+import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.contax.model.person.exceptions.DuplicatePersonException;
 import seedu.contax.model.person.exceptions.PersonNotFoundException;
+import seedu.contax.model.tag.UniqueTagList;
 import seedu.contax.testutil.PersonBuilder;
 
 public class UniquePersonListTest {
@@ -199,6 +201,26 @@ public class UniquePersonListTest {
 
         assertTrue(result.contains(BOB));
         assertTrue(result.contains(ALICE));
+    }
+
+    @Test
+    public void equals() {
+        UniquePersonList personList = new UniquePersonList();
+        UniquePersonList list2 = new UniquePersonList();
+        list2.add(ALICE);
+
+        UniquePersonList list3 = new UniquePersonList();
+        list3.add(ALICE);
+
+        // Same tag list
+        assertTrue(personList.equals(personList));
+        assertTrue(personList.equals(new UniquePersonList()));
+        assertTrue(list2.equals(list3));
+
+        // Null checking
+        assertFalse(personList.equals(null));
+        assertFalse(personList.equals(list2));
+        assertFalse(personList.equals(0));
     }
 
 }

--- a/src/test/java/seedu/contax/model/tag/TagTest.java
+++ b/src/test/java/seedu/contax/model/tag/TagTest.java
@@ -1,5 +1,7 @@
 package seedu.contax.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,30 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    }
+
+    @Test
+    public void isSameTag() {
+        Tag tag1 = new Tag("test");
+        Tag tag2 = new Tag("different");
+
+        assertTrue(tag1.isSameTag(tag1));
+        assertTrue(tag1.isSameTag(new Tag("test")));
+
+        assertFalse(tag1.isSameTag(tag2));
+        assertFalse(tag1.isSameTag(null));
+    }
+
+    @Test
+    public void equals() {
+        Tag tag1 = new Tag("test");
+        Tag tag2 = new Tag("different");
+
+        assertTrue(tag1.equals(tag1));
+        assertTrue(tag1.equals(new Tag("test")));
+
+        assertFalse(tag1.equals(tag2));
+        assertFalse(tag1.equals(null));
     }
 
 }

--- a/src/test/java/seedu/contax/model/tag/UniqueTagListTest.java
+++ b/src/test/java/seedu/contax/model/tag/UniqueTagListTest.java
@@ -5,15 +5,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.testutil.Assert.assertThrows;
+import static seedu.contax.testutil.TypicalPersons.ALICE;
+import static seedu.contax.testutil.TypicalPersons.BOB;
 import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 import static seedu.contax.testutil.TypicalTags.CLIENTS;
+import static seedu.contax.testutil.TypicalTags.COLLEAGUES;
 import static seedu.contax.testutil.TypicalTags.FAMILY;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.contax.model.person.Person;
+import seedu.contax.model.person.UniquePersonList;
 import seedu.contax.model.tag.exceptions.DuplicateTagException;
 
 class UniqueTagListTest {
@@ -128,5 +134,21 @@ class UniqueTagListTest {
         assertEquals(list2.hashCode(), list3.hashCode());
 
         assertNotEquals(refList.hashCode(), list2.hashCode());
+    }
+
+    @Test
+    public void iterator() {
+        UniqueTagList refList = new UniqueTagList();
+
+        refList.add(FRIENDS);
+        refList.add(COLLEAGUES);
+
+        HashSet<Tag> result = new HashSet<>();
+        for (Tag x : refList) {
+            result.add(x);
+        }
+
+        assertTrue(result.contains(FRIENDS));
+        assertTrue(result.contains(COLLEAGUES));
     }
 }

--- a/src/test/java/seedu/contax/model/tag/UniqueTagListTest.java
+++ b/src/test/java/seedu/contax/model/tag/UniqueTagListTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.contax.testutil.Assert.assertThrows;
-import static seedu.contax.testutil.TypicalPersons.ALICE;
-import static seedu.contax.testutil.TypicalPersons.BOB;
 import static seedu.contax.testutil.TypicalPersons.FRIENDS;
 import static seedu.contax.testutil.TypicalTags.CLIENTS;
 import static seedu.contax.testutil.TypicalTags.COLLEAGUES;
@@ -18,8 +16,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.contax.model.person.Person;
-import seedu.contax.model.person.UniquePersonList;
 import seedu.contax.model.tag.exceptions.DuplicateTagException;
 
 class UniqueTagListTest {


### PR DESCRIPTION
# Changes
This PR adds defense mechanisms relating to `AddressBook#resetData()` and adds test cases (equality check in particular) for existing model classes.

# Related Issues
None.