### PR TITLE
Fix Obvious Issues With Batch and Range

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -578,8 +578,8 @@ Performs operations on contacts in the address book that match the given conditi
 Format: `batch COMMAND by/FIELD [=/EQUALS_VALUE] [start/START_WITH] [end/END_WITH]`
 
 * `COMMAND` must be a valid command without `INDEX`. The allowed operations in `COMMAND` are:
-  * edit
-  * delete
+  * editperson
+  * deleteperson
 * The `FIELD` provided must be provided, and must match one of the following:
   * `Name`
   * `Address`
@@ -609,8 +609,8 @@ Format: `range COMMAND from/INDEX_FROM to/INDEX_TO`
 
 * Performs the specified `COMMAND` on all contacts between the specified range of `INDEX_FROM` to `INDEX_TO` inclusive.
 * `COMMAND` must be a valid command without `INDEX`. The allowed operations in `COMMAND` are:
-  * edit
-  * delete
+  * editperson
+  * deleteperson
 * The `INDEX_FROM` and `INDEX_TO` parameters must be **positive integers**, and refer to the [index number](#displayed-indexes) shown in the **displayed person list**.
 * `INDEX_FROM` must be less than `INDEX_TO` supplied, otherwise the command will fail.
 * The resultant effect of the command is dependent on the performed action.

--- a/src/main/java/seedu/contax/logic/commands/BatchCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/BatchCommand.java
@@ -21,8 +21,7 @@ import seedu.contax.model.Model;
 import seedu.contax.model.person.Person;
 import seedu.contax.model.util.SearchType;
 
-
-
+//@@author HanJiyao
 /**
  * Batch edits or deletes a person identified using base on string =/ provided.
  */
@@ -87,13 +86,21 @@ public class BatchCommand extends Command {
         Collections.reverse(indexList);
         List<CommandResult> commandResultList = new ArrayList<>();
         Person restorePerson = model.getFilteredPersonList().get(indexList.get(0).getZeroBased());
+        AddressBookParser addressBookParser = new AddressBookParser();
+
         for (Index index: indexList) {
-            AddressBookParser addressBookParser = new AddressBookParser();
             try {
                 String commandText = ParserUtil.parseAndCreateNewCommand(
                         commandInput, Integer.toString(index.getOneBased()));
+
+                if (!commandText.startsWith(EditPersonCommand.COMMAND_WORD)
+                        && !commandText.startsWith(DeletePersonCommand.COMMAND_WORD)) {
+                    throw new CommandException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            BatchCommand.MESSAGE_USAGE));
+                }
                 logger.info("----------------[BATCH COMMAND][" + commandText + "]");
                 Command command = addressBookParser.parseCommand(commandText);
+
                 try {
                     commandResultList.add(command.execute(model));
                 } catch (CommandException ce) {

--- a/src/main/java/seedu/contax/logic/commands/RangeCommand.java
+++ b/src/main/java/seedu/contax/logic/commands/RangeCommand.java
@@ -1,6 +1,7 @@
 package seedu.contax.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.contax.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.contax.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.contax.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.contax.logic.parser.CliSyntax.PREFIX_RANGE_FROM;
@@ -20,13 +21,14 @@ import seedu.contax.logic.parser.exceptions.ParseException;
 import seedu.contax.model.Model;
 import seedu.contax.model.person.Person;
 
+//@@author HanJiyao
 /**
  * Range edit or delete a person identified using it's displayed from index and to index from the address book.
  */
 public class RangeCommand extends Command {
     public static final String COMMAND_WORD = "range";
 
-    public static final String MESSAGE_USAGE = "`" + COMMAND_WORD + "`: **Perform command in range"
+    public static final String MESSAGE_USAGE = "`" + COMMAND_WORD + "`: **Perform command in range "
             + "by the index number used in the displayed person list.**"
             + "\nParameters: *"
             + "COMMAND (must be valid command without index) "
@@ -66,10 +68,19 @@ public class RangeCommand extends Command {
         Person restorePerson = model.getFilteredPersonList().get(toIndex.getZeroBased());
         for (int i = toIndex.getOneBased(); i >= fromIndex.getOneBased(); i--) {
             AddressBookParser addressBookParser = new AddressBookParser();
+
             try {
                 String commandText = ParserUtil.parseAndCreateNewCommand(commandInput, Integer.toString(i));
+
+                if (!commandText.startsWith(EditPersonCommand.COMMAND_WORD)
+                        && !commandText.startsWith(DeletePersonCommand.COMMAND_WORD)) {
+                    throw new CommandException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            RangeCommand.MESSAGE_USAGE));
+                }
+
                 logger.info("----------------[RANGE COMMAND][" + commandText + "]");
                 Command command = addressBookParser.parseCommand(commandText);
+
                 try {
                     commandResultList.add(command.execute(model));
                 } catch (CommandException ce) {


### PR DESCRIPTION
## Changes
This PR fixes the fact that `batch` and `range` do not reject the commands that should be rejected according to the user guide.

## Related Issues
- None, but this is a urgent fix.