### PR TITLE
Fix Urgent Visual Bug with Random Person Row Heights

### DIFF
--- a/src/main/java/seedu/contax/ui/PersonCard.java
+++ b/src/main/java/seedu/contax/ui/PersonCard.java
@@ -84,7 +84,7 @@ public class PersonCard extends UiPart<Region> implements RecyclableCard<Person>
     private Label createLabel(String tagName) {
         Label label = new Label(tagName);
         label.setWrapText(true);
-        label.maxWidthProperty().bind(cardPane.widthProperty());
+        label.setMaxWidth(400);
         return label;
     }
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,7 +27,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="tags" />
+      <FlowPane fx:id="tags" minWidth="100.0" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />


### PR DESCRIPTION
## Changes
If you currently attempt to perform `deleteperson 4` on a list with 4 persons, the row height jumps after you delete, which is not intended.

This change hardcodes a width for tag labels to solve this issue.